### PR TITLE
Initial branding updates

### DIFF
--- a/bluehost.php
+++ b/bluehost.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Plugin Name: MOJO Marketplace
- * Description: This plugin adds shortcodes, widgets, and themes to your WordPress site.
- * Version: 1.4.2
- * Author: Mike Hansen
- * Author URI: http://mikehansen.me?utm_campaign=plugin&utm_source=mojo_wp_plugin
+ * Plugin Name: Bluehost
+ * Description: This plugin integrates your WordPress site with the Bluehost control panel, including performance, security, and update features.
+ * Version: 1.4.3
+ * Author: Bluehost
+ * Author URI: https://www.bluehost.com/
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *
- * @package Mojo Marketplace
+ * @package Bluehost
  */
 
 // Do not access file directly!
@@ -16,10 +16,13 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'MM_VERSION', '1.4.2' );
+// Define constants
+define( 'MM_VERSION', '1.4.3' );
 define( 'MM_BASE_DIR', plugin_dir_path( __FILE__ ) );
 define( 'MM_BASE_URL', plugin_dir_url( __FILE__ ) );
 define( 'MM_ASSETS_URL', 'https://www.mojomarketplace.com/mojo-plugin-assets/' );
+
+define( 'BLUEHOST_PLUGIN_VERSION', MM_VERSION );
 
 // Composer autoloader
 if ( version_compare( phpversion(), 5.3, '<' ) ) {
@@ -28,6 +31,27 @@ if ( version_compare( phpversion(), 5.3, '<' ) ) {
 	require dirname( __FILE__ ) . '/vendor/autoload.php';
 }
 
+// Handle any upgrade routines
+if ( is_admin() ) {
+
+	require dirname( __FILE__ ) . '/inc/upgrade-handler.php';
+
+	$upgrade_handler = new Bluehost_Upgrade_Handler(
+		dirname( __FILE__ ) . '/upgrades',
+		get_option( 'bluehost_plugin_version', BLUEHOST_PLUGIN_VERSION ),
+		BLUEHOST_PLUGIN_VERSION
+	);
+
+	$did_upgrade = $upgrade_handler->maybe_upgrade();
+	if ( $did_upgrade ) {
+		update_option( 'bluehost_plugin_version', BLUEHOST_PLUGIN_VERSION, true );
+	}
+
+	require __DIR__ . '/upgrades/1.4.3.php';
+
+}
+
+// Require files
 require_once MM_BASE_DIR . 'inc/base.php';
 require_once MM_BASE_DIR . 'inc/checkout.php';
 require_once MM_BASE_DIR . 'inc/menu.php';

--- a/bluehost.php
+++ b/bluehost.php
@@ -47,8 +47,6 @@ if ( is_admin() ) {
 		update_option( 'bluehost_plugin_version', BLUEHOST_PLUGIN_VERSION, true );
 	}
 
-	require __DIR__ . '/upgrades/1.4.3.php';
-
 }
 
 // Require files

--- a/inc/branding.php
+++ b/inc/branding.php
@@ -1,20 +1,7 @@
 <?php
 
 function mm_brand( $format = '%s' ) {
-	$mm_brand = get_option( 'mm_brand', 'default' );
-
-	$brands = mm_api_cache( MM_ASSETS_URL . 'json/branding.json' );
-
-	if ( ! is_wp_error( $brands ) && $brands = json_decode( $brands['body'] ) ) {
-		if ( property_exists( $brands, $mm_brand ) ) {
-			$brand = $brands->{$mm_brand};
-		}
-	}
-
-	if ( ! isset( $brand ) || empty( $brand ) || 'quickinstall' == $brand ) {
-		$brand = 'default';
-	}
-	return sprintf( $format, sanitize_title( $brand ) );
+	return sprintf( $format, 'bluehost' );
 }
 
 function mm_plugin_details( $all_plugins ) {

--- a/inc/menu.php
+++ b/inc/menu.php
@@ -10,10 +10,7 @@ function mm_main_menu() {
 		}
 	}
 
-	$menu_position = -10;
-	$menu_name = 'Bluehost';
-
-	add_menu_page( $menu_name, $menu_name, 'manage_options', 'mojo-marketplace', 'mm_marketplace_page', 'data:image/svg+xml;base64, ' . $icon_hash, $menu_position );
+	add_menu_page( 'Bluehost', 'Bluehost', 'manage_options', 'mojo-marketplace', 'mm_marketplace_page', 'data:image/svg+xml;base64, ' . $icon_hash, -10 );
 
 }
 add_action( 'admin_menu', 'mm_main_menu' );

--- a/inc/menu.php
+++ b/inc/menu.php
@@ -9,24 +9,9 @@ function mm_main_menu() {
 			set_transient( 'mm_icon_hash', $icon_hash, WEEK_IN_SECONDS );
 		}
 	}
-	$brand = get_option( 'mm_brand' );
-	if ( false !== $brand ) {
-		$menu_position = -10;
-		$menu_name = $brand;
-	} else {
-		$menu_position = 59;
-		$menu_name = 'Marketplace';
-	}
 
-	if ( 'BlueHost' == $menu_name ) {
-		$menu_name = 'Bluehost';
-	}
-
-	if ( 'Bluehost_India' == $menu_name ) {
-		$menu_name = 'Bluehost';
-	}
-
-	$menu_name = str_replace( '_', ' ', $menu_name );
+	$menu_position = -10;
+	$menu_name = 'Bluehost';
 
 	add_menu_page( $menu_name, $menu_name, 'manage_options', 'mojo-marketplace', 'mm_marketplace_page', 'data:image/svg+xml;base64, ' . $icon_hash, $menu_position );
 

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -29,20 +29,10 @@ function mm_auto_update_register_settings() {
 	$section_name = 'mm_auto_update_settings_section';
 	$section_hook = 'general';
 
-	if ( 'bluehost' == mm_brand() ) {
-		$brand = 'Bluehost';
-	} else {
-		$brand = 'Host';
-	}
-
 	if ( ! defined( 'AUTOMATIC_UPDATER_DISABLED' ) ) {
-		$brand = get_option( 'mm_brand', 'MOJO' );
-		if ( 'BlueHost' == $brand ) {
-			$brand = 'Bluehost';
-		}
 		add_settings_section(
 			$section_name,
-			$brand . ' Auto Update Manager',
+			'Bluehost Auto Update Manager',
 			'__return_false',
 			$section_hook
 		);

--- a/inc/upgrade-handler.php
+++ b/inc/upgrade-handler.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Class Bluehost_Upgrade_Handler
+ *
+ * Responsible for managing upgrade routines.
+ */
+class Bluehost_Upgrade_Handler {
+
+	/**
+	 * The previous version.
+	 *
+	 * @var string
+	 */
+	protected $old_version;
+
+	/**
+	 * The current version.
+	 *
+	 * @var string
+	 */
+	protected $new_version;
+
+	/**
+	 * The directory containing upgrade routines.
+	 *
+	 * @var string
+	 */
+	protected $upgrade_dir;
+
+	/**
+	 * Bluehost_Upgrade_Handler constructor.
+	 *
+	 * @param string $upgrade_dir The directory containing upgrade routines.
+	 * @param string $old_version The previous version.
+	 * @param string $new_version The current version.
+	 */
+	public function __construct( $upgrade_dir, $old_version, $new_version ) {
+		$this->upgrade_dir = $upgrade_dir;
+		$this->old_version = $old_version;
+		$this->new_version = $new_version;
+	}
+
+	/**
+	 * Detect when an upgrade is necessary and run the updates.
+	 *
+	 * @return bool Whether or not an upgrade routine ran.
+	 */
+	public function maybe_upgrade() {
+		$should_upgrade = $this->should_upgrade();
+		if ( $should_upgrade ) {
+			$available_routines = $this->get_available_upgrade_routines();
+			$required_routines  = $this->get_required_upgrade_routines( $available_routines );
+			$this->run_upgrade_routines( $required_routines );
+		}
+
+		return $should_upgrade;
+	}
+
+	/**
+	 * Check if we should upgrade.
+	 *
+	 * @return bool
+	 */
+	public function should_upgrade() {
+		return $this->old_version !== $this->new_version;
+	}
+
+	/**
+	 * Get a collection of available upgrade routines.
+	 *
+	 * @return array A collection of filepaths indexed by versions.
+	 */
+	public function get_available_upgrade_routines() {
+		$routines  = array();
+		$filepaths = glob( rtrim( $this->upgrade_dir, '/' ) . '/*.php' );
+		if ( $filepaths ) {
+			$versions = str_replace( '.php', '', array_map( 'basename', $filepaths ) );
+			$routines = array_combine( $versions, $filepaths );
+		}
+
+		return $routines;
+	}
+
+	/**
+	 * Get a collection of the required upgrade routines.
+	 *
+	 * @param array $available_routines
+	 *
+	 * @return array A collection of filepaths indexed by versions.
+	 */
+	public function get_required_upgrade_routines( array $available_routines ) {
+		$routines = array();
+		$required = array_filter( array_keys( $available_routines ), array( $this, 'filter_upgrade_routines' ) );
+		if ( $required ) {
+			$routines = array_intersect_key( $available_routines, array_combine( $required, $required ) );
+		}
+
+		return $routines;
+	}
+
+	/**
+	 * Run an ordered set of upgrade routines.
+	 *
+	 * @param array $routines A collection of filepaths indexed by versions.
+	 */
+	public function run_upgrade_routines( array $routines ) {
+		foreach ( $routines as $file ) {
+			if ( file_exists( $file ) ) {
+				require $file;
+			}
+		}
+	}
+
+	/**
+	 * Filter to find the versions for which we need to run an upgrade routine.
+	 *
+	 * @param string $version
+	 *
+	 * @return bool Whether or not to keep the routine.
+	 */
+	protected function filter_upgrade_routines( $version ) {
+		return version_compare( $this->old_version, $version, '<' ) && version_compare( $this->new_version, $version, '>=' );
+	}
+
+}

--- a/pages/mojo-performance.php
+++ b/pages/mojo-performance.php
@@ -72,7 +72,7 @@ $php_edge_settings = get_option( 'mm_php_edge_settings', '56' );
 			</div>
 		</div>
 
-		<?php /* if ( get_option( 'mm_brand' ) == 'BlueHost' ) { ?>
+		<?php /* this feature is unusable due to ea4. Leaving the code until we are able to use it.
 		<div class="container">
 			<div class="panel panel-default">
 				<div class="panel-heading">
@@ -126,8 +126,7 @@ $php_edge_settings = get_option( 'mm_php_edge_settings', '56' );
 					</div>
 				</div>
 			</div>
-		</div>
-		<?php }  this feature is unusable due to ea4. Leaving the code until we are able to use it. */?>
+		</div> */?>
 
 	</main>
 </div>

--- a/upgrades/1.4.3.php
+++ b/upgrades/1.4.3.php
@@ -1,0 +1,7 @@
+<?php
+
+// Delete the `mm_brand` option. We've removed all situations where it is used.
+delete_option( 'mm_brand' );
+
+// Remove the icon hash transient, just in case it doesn't contain the Bluehost logo
+delete_transient( 'mm_icon_hash' );

--- a/upgrades/index.php
+++ b/upgrades/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is Golden.


### PR DESCRIPTION
Updated name of the main plugin file. Updated plugin headers to be Bluehost branded. Added upgrade handler. Updated version to 1.4.3 (can tag at any time later) and added upgrade routine for version 1.4.3. Removed all references to the `mm_brand` option.