### PR TITLE
Hotfix for date issue

### DIFF
--- a/inc/base.php
+++ b/inc/base.php
@@ -58,16 +58,11 @@ function bh_setup() {
 		update_option( 'mm_cron', $events );
 	}
 	if ( ! bh_has_plugin_install_date() ) {
+		$date = false;
 		if ( ! empty( $install_date ) ) {
-			try {
-				$date = DateTime::createFromFormat( 'M d, Y', $install_date );
-				bh_set_plugin_install_date( $date->format( 'U' ) );
-			} catch ( Exception $e ) {
-				bh_set_plugin_install_date( gmdate( 'U' ) );
-			}
-		} else {
-			bh_set_plugin_install_date( gmdate( 'U' ) );
+			$date = DateTime::createFromFormat( 'M d, Y', $install_date );
 		}
+		bh_set_plugin_install_date( $date ? $date->format( 'U' ) : gmdate( 'U' ) );
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Fix issue where invalid `mm_install_date` was preventing `bh_plugin_install_date` from being set properly.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)