### PR TITLE
Fix incorrect query parameter ordering.

### DIFF
--- a/lib/.staging
+++ b/lib/.staging
@@ -162,7 +162,7 @@ function sso_staging {
 		error 'No user provided.'
 	fi
 	LINK=$(wp mojo sso --url-only --id=$1 --path=$STAGING_DIR)
-	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=mojo-staging\"\}
+	echo \{\"status\":\"success\",\"load_page\":\"$LINK\?redirect=admin.php\&page=bluehost#\/tools\/staging\"\}
 }
 
 function sso_production {
@@ -171,7 +171,7 @@ function sso_production {
 		error 'No user provided.'
 	fi
 	LINK=$(wp mojo sso --url-only --id=$1 --path=$PRODUCTION_DIR)
-	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=mojo-staging\"\}
+	echo \{\"status\":\"success\",\"load_page\":\"$LINK\?redirect=admin.php\&page=bluehost#\/tools\/staging\"\}
 }
 
 function error {

--- a/lib/.staging
+++ b/lib/.staging
@@ -161,7 +161,7 @@ function sso_staging {
 		then
 		error 'No user provided.'
 	fi
-	LINK=$(wp mojo sso --url-only --id=$1 --path=$STAGING_DIR)
+	LINK=$(wp bluehost sso --url-only --id=$1 --path=$STAGING_DIR)
 	echo \{\"status\":\"success\",\"load_page\":\"$LINK\?redirect=admin.php\&page=bluehost#\/tools\/staging\"\}
 }
 
@@ -170,7 +170,7 @@ function sso_production {
 		then
 		error 'No user provided.'
 	fi
-	LINK=$(wp mojo sso --url-only --id=$1 --path=$PRODUCTION_DIR)
+	LINK=$(wp bluehost sso --url-only --id=$1 --path=$PRODUCTION_DIR)
 	echo \{\"status\":\"success\",\"load_page\":\"$LINK\?redirect=admin.php\&page=bluehost#\/tools\/staging\"\}
 }
 


### PR DESCRIPTION
The `?` was after the second parameter, not the first. The old mojo parameter was also used.

Fixes #34.