### PR TITLE
Jetpack Updates

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -17,23 +17,33 @@ function bluehost_customize_jetpack_default_modules( $modules ) {
 add_filter( 'jetpack_get_default_modules', 'bluehost_customize_jetpack_default_modules' );
 
 /**
- * Unregister the MailChimp block.
+ * Unregister Jetpack blocks that we do not want enabled by default.
  *
  * @param array $blocks Collection of registered blocks.
  *
  * @return array
  */
-function bluehost_jetpack_unregister_mailchimp_block( $blocks ) {
-	$found = array_search( 'mailchimp', $blocks, true );
-	if ( false !== $found ) {
-		unset( $blocks[ $found ] );
+function bluehost_jetpack_unregister_blocks( $blocks ) {
+	$blocks_to_deregister = array(
+		'mailchimp',
+		'revue',
+	);
+	foreach ( $blocks_to_deregister as $block_slug ) {
+		$found = array_search( $block_slug, $blocks, true );
+		if ( false !== $found ) {
+			unset( $blocks[ $found ] );
+		}
 	}
-
 	return $blocks;
 }
 
-add_filter( 'jetpack_set_available_blocks', 'bluehost_jetpack_unregister_mailchimp_block' );
+add_filter( 'jetpack_set_available_blocks', 'bluehost_jetpack_unregister_blocks' );
 
+/**
+ * Provides links that the SSO can utilize to redirect customers directly to the Jetpack connection.
+ *
+ * @return array
+ */
 function bluehost_jetpack_connection_redirect() {
 	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'mojo-jetpack-connect-bounce', 'bluehost-jetpack-connect-bounce' ) ) ) {
 		if ( class_exists( 'Jetpack' ) ) {
@@ -44,4 +54,5 @@ function bluehost_jetpack_connection_redirect() {
 		}
 	}
 }
+
 add_action( 'admin_init', 'bluehost_jetpack_connection_redirect' );

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -42,7 +42,7 @@ add_filter( 'jetpack_set_available_blocks', 'bluehost_jetpack_unregister_blocks'
 /**
  * Provides links that the SSO can utilize to redirect customers directly to the Jetpack connection.
  *
- * @return array
+ * @return void
  */
 function bluehost_jetpack_connection_redirect() {
 	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'mojo-jetpack-connect-bounce', 'bluehost-jetpack-connect-bounce' ) ) ) {

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -56,3 +56,14 @@ function bluehost_jetpack_connection_redirect() {
 }
 
 add_action( 'admin_init', 'bluehost_jetpack_connection_redirect' );
+
+/**
+ * Registers non-menu pages to leverage as redirects for the Jetpack connection.
+ *
+ * @return void
+ */
+function bluehost_jetpack_connect_menu() {
+	add_submenu_page( null, __( 'Connect Jetpack', 'bluehost-wordpress-plugin' ), __( 'Connect Jetpack', 'bluehost-wordpress-plugin' ), 'manage_options', 'mojo-jetpack-connect-bounce', '__return_false' );
+	add_submenu_page( null, __( 'Connect Jetpack', 'bluehost-wordpress-plugin' ), __( 'Connect Jetpack', 'bluehost-wordpress-plugin' ), 'manage_options', 'bluehost-jetpack-connect-bounce', '__return_false' );
+}
+add_action( 'admin_menu', 'bluehost_jetpack_connect_menu' );

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -33,3 +33,15 @@ function bluehost_jetpack_unregister_mailchimp_block( $blocks ) {
 }
 
 add_filter( 'jetpack_set_available_blocks', 'bluehost_jetpack_unregister_mailchimp_block' );
+
+function bluehost_jetpack_connection_redirect() {
+	if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'mojo-jetpack-connect-bounce', 'bluehost-jetpack-connect-bounce' ) ) ) {
+		if ( class_exists( 'Jetpack' ) ) {
+			wp_redirect( Jetpack::init()->build_connect_url( true ), 302 );
+		} else {
+			// In the future this should be a Jetpack product page.
+			wp_safe_redirect( admin_url( 'admin.php?page=bluehost' ), 301 );
+		}
+	}
+}
+add_action( 'admin_init', 'bluehost_jetpack_connection_redirect' );

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -50,7 +50,7 @@ function bluehost_jetpack_connection_redirect() {
 			wp_redirect( Jetpack::init()->build_connect_url( true ), 302 );
 		} else {
 			// In the future this should be a Jetpack product page.
-			wp_safe_redirect( admin_url( 'admin.php?page=bluehost' ), 301 );
+			wp_safe_redirect( admin_url( 'admin.php?page=bluehost' ), 302 );
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

Brings over some redirect logic for Jetpack connections coming from Bluerock. It includes the mojo prefixed param for back-compat until we can get it updated. It should be removed at a future date. 

This also pulls over the more current list of blocks that should not be enabled by default from the mojo plugin.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
