### PR TITLE
Fix issue where plugin updates don't work via WP CLI

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,7 +10,7 @@ define( 'MOJO_ASSETS_URL', 'https://www.mojomarketplace.com/mojo-plugin-assets/'
 require __DIR__ . '/vendor/autoload.php';
 
 // Handle plugin updates
-if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
+if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 	new Updater( 'bluehost', 'bluehost-wordpress-plugin', 'bluehost-wordpress-plugin/bluehost-wordpress-plugin.php' );
 }
 


### PR DESCRIPTION
## Proposed changes

Fix issue where plugin updates don't work via WP CLI

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

