### PR TITLE
Remove flash of webkit focus ring on Link Buttons

### DIFF
--- a/assets/admin-global.css
+++ b/assets/admin-global.css
@@ -28,9 +28,6 @@ body.admin_page_mojo-theme-preview .wp-full-overlay-sidebar{
   .components-button.bluehost.is-link {
     font-weight: 300;
     color: #3575d3; }
-    .components-button.bluehost.is-link:hover {
-      color: #3575d3;
-      text-decoration: underline; }
   .components-button.bluehost.is-default {
     border-color: #ccc;
     background: #f7f7f7;

--- a/src/app/components/atoms/bwa-button/style.scss
+++ b/src/app/components/atoms/bwa-button/style.scss
@@ -47,12 +47,16 @@ body *.components-button.bluehost {
   }
 
   &.is-link {
-    font-weight: 300;
+    font-weight: 600;
     color: $color-primary;
 
     &:hover {
       color: $color-dark-blue !important;
       text-decoration: none !important;
+    }
+    &:focus {
+      outline: none !important;
+      box-shadow: none !important;
     }
   }
 


### PR DESCRIPTION
## Proposed changes

Removes 0.08s appearance of webkit focus ring on Link Buttons that appeared on click or briefly via devtools `:active`.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

