### PR TITLE
Allow hub url override for local dev

### DIFF
--- a/inc/Notifications/NotificationsRepository.php
+++ b/inc/Notifications/NotificationsRepository.php
@@ -33,8 +33,9 @@ class NotificationsRepository {
 		$notifications = get_transient( self::TRANSIENT );
 
 		if ( false === $notifications ) {
+			$api_base = ( defined( 'BH_HUB_URL' ) ) ? BH_HUB_URL : 'https://hiive.cloud/api';
 			$response = wp_remote_get(
-				'https://hiive.cloud/api/notifications',
+				$api_base . '/notifications',
 				array(
 					'headers' => array(
 						'Content-Type'  => 'application/json',


### PR DESCRIPTION
## Proposed changes

When testing anything locally, the hardcoded hub domain in the `NotificationsRepository` class ends up causing those requests to return 401, since the local site can't connect to it. 

In the data module, I have a `BH_HUB_URL` constant that gets checked and set. This would allow a local override when testing any data/notifications using the local stack. 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)