### PR TITLE
Add support for auto-updates of major versions in WP 5.6

### DIFF
--- a/inc/RestApi/SettingsController.php
+++ b/inc/RestApi/SettingsController.php
@@ -73,6 +73,12 @@ class SettingsController extends \WP_REST_Controller {
 					case 'autoUpdatesMajorCore':
 						$new_value = ( $new_value ) ? 'true' : 'false';
 						update_option( 'allow_major_auto_core_updates', $new_value );
+
+						if ( 'true' === $new_value ) {
+							update_option( 'auto_update_core_major', 'enabled' );
+						} else {
+							update_option( 'auto_update_core_major', 'disabled' );
+						}
 						break;
 					case 'autoUpdatesMinorCore':
 						update_option( 'allow_minor_auto_core_updates', $new_value );

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -196,4 +196,4 @@ function bh_sync_plugin_major_auto_core_update_option( $old_value, $value ) {
 	}
 }
 
-add_filter( 'update_option_auto_update_core_major', 'bh_sync_plugin_major_auto_core_update_option', 10, 2 );
+add_action( 'update_option_auto_update_core_major', 'bh_sync_plugin_major_auto_core_update_option', 10, 2 );

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -204,7 +204,7 @@ add_action( 'update_option_auto_update_core_major', 'bh_sync_plugin_major_auto_c
  * @param int $wp_db_version         The new $wp_db_version.
  * @param int $wp_current_db_version The old (current) $wp_db_version.
  */
-function ( $wp_db_version, $wp_current_db_version ) {
+function bh_core_update_560( $wp_db_version, $wp_current_db_version ) {
 	if ( 49572 > $wp_current_db_version && 49572 < $wp_db_version ) {
 		$update_option = get_option( 'allow_major_auto_core_updates', 'true' );
 
@@ -216,4 +216,4 @@ function ( $wp_db_version, $wp_current_db_version ) {
 	}
 }
 
-add_action( 'wp_upgrade', '', 10, 2 );
+add_action( 'wp_upgrade', 'bh_core_update_560', 10, 2 );

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -69,6 +69,11 @@ function bh_auto_update_configure() {
 
 		$settings = array_map( 'bh_auto_update_make_bool', $settings );
 
+		// WordPress 5.6 introduces the ability to opt-in to major updates. Let Core handle this now.
+		if ( version_compare( $wp_version, '5.6', '>=' ) ) {
+			unset( $settings['allow_major_auto_core_updates'] );
+		}
+
 		// If plugin or theme settings are disabled, allow the site admin to manage auto-updates in WordPress.
 		if ( false === $settings['auto_update_plugin'] && version_compare( $wp_version, '5.5.0', '>=' ) ) {
 			unset( $settings['auto_update_plugin'] );
@@ -172,3 +177,23 @@ function bh_theme_auto_update_setting_template( $template ) {
 }
 
 add_filter( 'theme_auto_update_setting_template', 'bh_theme_auto_update_setting_template' );
+
+/**
+ * Sync the plugin's Core major auto-update setting with core's.
+ *
+ * @param mixed  $old_value The old option value.
+ * @param mixed  $value     The new option value.
+ */
+function bh_sync_plugin_major_auto_core_update_option( $old_value, $value ) {
+	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		return;
+	}
+
+	if ( 'disabled' === $value ) {
+		update_option( 'allow_major_auto_core_updates', 'false' );
+	} else {
+		update_option( 'allow_major_auto_core_updates', 'true' );
+	}
+}
+
+add_filter( 'update_option_auto_update_core_major', 'bh_sync_plugin_major_auto_core_update_option', 10, 2 );

--- a/inc/updates.php
+++ b/inc/updates.php
@@ -197,3 +197,23 @@ function bh_sync_plugin_major_auto_core_update_option( $old_value, $value ) {
 }
 
 add_action( 'update_option_auto_update_core_major', 'bh_sync_plugin_major_auto_core_update_option', 10, 2 );
+
+/**
+ * When upgrading from < 5.6, sync the plugin option with Core's new option.
+ *
+ * @param int $wp_db_version         The new $wp_db_version.
+ * @param int $wp_current_db_version The old (current) $wp_db_version.
+ */
+function ( $wp_db_version, $wp_current_db_version ) {
+	if ( 49572 > $wp_current_db_version && 49572 < $wp_db_version ) {
+		$update_option = get_option( 'allow_major_auto_core_updates', 'true' );
+
+		if ( 'false' === $update_option ) {
+			update_option( 'auto_update_core_major', 'disabled' );
+		} else {
+			update_option( 'auto_update_core_major', 'enabled' );
+		}
+	}
+}
+
+add_action( 'wp_upgrade', '', 10, 2 );

--- a/upgrades/2.5.0.php
+++ b/upgrades/2.5.0.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Handle updates for version 2.5.0.
+ *
+ * @package Bluehost
+ */
+
+// Sync the plugin's auto-update setting with the new one in WP Core for major auto-updates.
+$plugin_auto_update = get_option( 'allow_major_auto_core_updates', 'true' );
+
+if ( 'false' === $plugin_auto_update ) {
+	update_option( 'auto_update_core_major', 'disabled' );
+} else {
+	update_option( 'auto_update_core_major', 'enabled' );
+}


### PR DESCRIPTION
## Proposed changes

WP 5.6 adds a UI element that allows site owners to opt-in to auto-updates for major version releases, and new installs will be opted-in by default.

Because the plugin was using the `allow_major_auto_core_updates` filter to implement the auto-update behavior chosen in the plugin, the text on the Core updates screen in the admin was incorrect. The core setting could also be toggled, but it would not affect the behavior of updates because of the plugin's filter.

This changes the behavior of the plugin for auto-updates on sites using WordPress 5.6 or higher to "step out of the way" to let the new code in Core manage the updates while maintaining the option that the plugin previously depended on for backwards compatibility (just in case a user downgrades their install).

## Type of Change

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
