### PR TITLE
Fix/issue 74 login redirect

### DIFF
--- a/languages/bluehost-wordpress-plugin.pot
+++ b/languages/bluehost-wordpress-plugin.pot
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Bluehost
+# Copyright (C) 2021 Bluehost
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""


### PR DESCRIPTION
## Proposed changes

Fix issue #74 where non-admin users are redirected to the admin-only Bluehost dashboard page.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
