### PR TITLE
Fix Analytics: Add admin.php prefix to analytics URLs

### DIFF
--- a/src/app/functions/sendPageviewEvent.js
+++ b/src/app/functions/sendPageviewEvent.js
@@ -13,7 +13,7 @@ const sendPageviewEvent = (location, title = false) => {
         data: {}
     };
 
-    payload.data.page           = window.bluehostWpAdminUrl + '?page=bluehost#' + location.pathname; // full url
+    payload.data.page           = window.bluehostWpAdminUrl + 'admin.php?page=bluehost#' + location.pathname; // full url
     if ( title ) {
         payload.data['page_title']  = title;
     }


### PR DESCRIPTION
## Proposed changes

Fixes issue where analytics URLs lacked `admin.php` and were reported as `/wp-admin/?page=bluehost` instead of `/wp-admin/admin.php?page=bluehost`.

* window.bluehostWpAdminUrl is [set via](https://github.com/bluehost/bluehost-wordpress-plugin/blob/master/inc/admin/class-assets.php#L239) `wp_localize_script()` with `admin_url()`.


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
