### PR TITLE
Fix wp.a11y logic

### DIFF
--- a/src/app/components/templates/bwa-base/index.js
+++ b/src/app/components/templates/bwa-base/index.js
@@ -64,7 +64,7 @@ const BWABaseTemplate = ({
 		if ( 
 			'undefined' !== typeof location.state
 			&& 'undefined' !== typeof location.state.redirect
-			&& 'unspecified-or-root' === typeof location.state.redirect 
+			&& 'unspecified-or-root' === location.state.redirect 
 		) {
 			return; // don't speak Home title on load (rely on browser behavior), but speak on subsequent navigation to Home
 		}

--- a/src/app/components/templates/bwa-base/index.js
+++ b/src/app/components/templates/bwa-base/index.js
@@ -60,13 +60,23 @@ const BWABaseTemplate = ({
 		}
 	}
 
+	const speakRouteTitle = ( location, title ) => {
+		if ( 
+			'undefined' !== typeof location.state
+			&& 'undefined' !== typeof location.state.redirect
+			&& 'unspecified-or-root' === typeof location.state.redirect 
+		) {
+			return; // don't speak Home title on load (rely on browser behavior), but speak on subsequent navigation to Home
+		}
+
+		speak( title, 'assertive' );
+	}
+
 	useEffect(() => {
 		handleWPMenuAugmentation(topLevelPages);
 		handleWPMenuActiveHighlight( getTopLevelActiveHighlightSlug() );
 		pageContainer.focus({ preventScroll: true });
-		if ( routerLocation.state && routerLocation.state.redirect !== 'unspecified-or-root' ) {
-			speak( getDescriptivePageTitle(), 'assertive' );
-		}
+		speakRouteTitle( routerLocation, getDescriptivePageTitle() );
 		sendPageviewEvent(routerLocation, getDescriptivePageTitle() );
 	}, [routerLocation.pathname]);
 


### PR DESCRIPTION
## Proposed changes

When I added the wp.a11y.speak logic, during testing I tried to scope the code to exclude announcing the first pageload if it was the Home Page, as this effectively dupes existing screen reader behavior to announce the document title. However, subsequent route changes -- including Home Page -- should be included. I confirmed this had the desired effect on Home, but didn't check the scoping on other routes, which were now excluded.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

