### PR TITLE
Fix staging URL redirect

### DIFF
--- a/lib/.staging
+++ b/lib/.staging
@@ -173,7 +173,7 @@ function sso_production {
 	fi
 	wp eval 'file_exists( WPMU_PLUGIN_DIR . "/sso.php" ) ? unlink( WPMU_PLUGIN_DIR . "/sso.php" ) : null;' --path=$PRODUCTION_DIR
 	LINK=$(wp bluehost sso --url-only --id=$1 --path=$PRODUCTION_DIR)
-	echo \{\"status\":\"success\",\"load_page\":\"$LINK\&redirect=admin.php\?page=bluehost#\/tools\/staging\"\}
+	echo \{\"status\":\"success\",\"load_page\":\"$LINK\admin.php\?page=bluehost#\/tools\/staging\"\}
 }
 
 function error {


### PR DESCRIPTION
## Proposed changes

Nix breaking issue in staging redirects from staging into production environment.

Bad URL example:
```
http://boxXXX.temp.domains/~XXXX/staging/XXXX/wp-admin/&redirect=admin.php?page=bluehost#/tools/staging
```

@wpscholar you last touched this in #47 -- anything I'm missing here?

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
