### PR TITLE
Accomodate Mutliplatform URLs in Admin App

### DIFF
--- a/inc/admin/class-assets.php
+++ b/inc/admin/class-assets.php
@@ -107,6 +107,6 @@ class Bluehost_Admin_App_Assets {
 		BuildAssets::inlineWebpackPublicPath( 'bwp-manifest-app' );
 		\wp_localize_script( 'bwp-manifest-app', 'bluehost', apply_filters( 'bluehost_admin_page_data', $data ) );
 		\wp_add_inline_script( 'bwp-manifest-app', 'window.bluehostWpAdminUrl="' . \admin_url() . '";', 'before' );
-		\wp_add_inline_script( 'bwp-manifest-app', 'window.nfBrandPlatform="' . \get_option('mm_brand') . '";', 'before' );
+		\wp_add_inline_script( 'bwp-manifest-app', 'window.nfBrandPlatform="' . \get_option( 'mm_brand' ) . '";', 'before' );
 	}
 }

--- a/inc/admin/class-assets.php
+++ b/inc/admin/class-assets.php
@@ -68,7 +68,6 @@ class Bluehost_Admin_App_Assets {
 	/**
 	 * Register Page JS
 	 *
-	 * @param string $dist_url Base distribution URL.
 	 */
 	protected function prepareData() {
 

--- a/inc/admin/class-assets.php
+++ b/inc/admin/class-assets.php
@@ -67,7 +67,6 @@ class Bluehost_Admin_App_Assets {
 
 	/**
 	 * Register Page JS
-	 *
 	 */
 	protected function prepareData() {
 

--- a/inc/admin/class-assets.php
+++ b/inc/admin/class-assets.php
@@ -107,5 +107,6 @@ class Bluehost_Admin_App_Assets {
 		BuildAssets::inlineWebpackPublicPath( 'bwp-manifest-app' );
 		\wp_localize_script( 'bwp-manifest-app', 'bluehost', apply_filters( 'bluehost_admin_page_data', $data ) );
 		\wp_add_inline_script( 'bwp-manifest-app', 'window.bluehostWpAdminUrl="' . \admin_url() . '";', 'before' );
+		\wp_add_inline_script( 'bwp-manifest-app', 'window.nfBrandPlatform="' . \get_option('mm_brand') . '";', 'before' );
 	}
 }

--- a/src/app/components/organisms/bwa-common-header/index.js
+++ b/src/app/components/organisms/bwa-common-header/index.js
@@ -10,7 +10,7 @@ import DesktopTabs from './desktop-tabs';
 import MobileSidebar from './mobile-sidebar';
 import { __ } from '@wordpress/i18n';
 import { Tooltip } from '@wordpress/components';
-import { addUtmParams } from "@app/functions";
+import { addUtmParams, getPlatformBaseUrl } from "@app/functions";
 
 const HeaderLogo = () => (
 	<div id="bluehost-logo-wrap">
@@ -18,7 +18,7 @@ const HeaderLogo = () => (
 			<a
 				href={
 					addUtmParams(
-						'https://my.bluehost.com/hosting/app',
+						getPlatformBaseUrl('/hosting/app'),
 						{
 							utm_content: 'bluehost_header_logo',
 							utm_term: 'Bluehost Logo linking to the Bluehost Control Panel'

--- a/src/app/functions/index.js
+++ b/src/app/functions/index.js
@@ -62,6 +62,26 @@ export function sendEvent(event) {
 	apiFetch({path: `/bluehost/v1/data/events/`, method: 'POST', data: event});
 }
 
+/**
+ * Get's Base Platform URL
+ * @param {string} path The path to a resource within the platform, leave blank for root.
+ * 
+ * @return {string}
+ */
+export function getPlatformBaseUrl( path = '' ) {
+	const brand = 'undefined' !== typeof window.nfBrandPlatform ? window.nfBrandPlatform : null;
+	const baseUrl = () => {
+		switch(brand) {
+			case 'Bluehost_India':
+				return 'https://my.bluehost.in';
+			default:
+				return 'https://my.bluehost.com';
+		}
+	}
+
+	return baseUrl() + path;
+}
+
 export { 
 	sendPageviewEvent,
 	handleWPMenuAugmentation,

--- a/src/app/menus/user.js
+++ b/src/app/menus/user.js
@@ -13,12 +13,12 @@ import {
 	UserIcon,
 	ValidationIcon,
 } from '@app/assets';
-import { addUtmParams } from '@app/functions';
+import { addUtmParams, getPlatformBaseUrl } from '@app/functions';
 
 /**
  * Component Defaults
  */
-const url = 'https://my.bluehost.com/hosting/';
+const url = getPlatformBaseUrl('/hosting/');
 
 let base = [
 	{
@@ -59,7 +59,7 @@ let base = [
 	{
 		icon: ValidationIcon,
 		id: 'validation_token_link',
-		href: 'https://my.bluehost.com/cgi/token',
+		href: getPlatformBaseUrl('/cgi/token'),
 		label: __('Validation Token', 'bluehost-wordpress-plugin'),
 		color: 'orange',
 	},

--- a/src/app/pages/blue-sky/index.js
+++ b/src/app/pages/blue-sky/index.js
@@ -24,7 +24,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { BWACommonTemplate as Page } from '@app/components/templates';
 import ReactPlayer from "react-player";
 import blueSkyGroup from '@app/assets/blue-sky-group.png';
-import { addUtmParams } from '@app/functions';
+import { addUtmParams, getPlatformBaseUrl } from '@app/functions';
 
 const BlueSky = () => {
 	return (
@@ -32,7 +32,7 @@ const BlueSky = () => {
 			<div className="bluesky-menu-backdrop" />
 			<BWAHeading level="h2" size={ 0 }>{ __('Blue Sky', 'bluehost-wordpress-plugin') }</BWAHeading>
 			<div className="section-logo">
-				<a href={addUtmParams('https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky')} aria-label={__('Blue Sky service logo', 'bluehost-wordpress-plugin')}>
+				<a href={addUtmParams(getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky'))} aria-label={__('Blue Sky service logo', 'bluehost-wordpress-plugin')}>
 					<BlueSkyLogo />
 				</a>
 			</div>
@@ -61,7 +61,7 @@ const BlueSky = () => {
 						</div>
 						<Button
 							className="media-block__button"
-							href="https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky"
+							href={getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky')}
 							utmContent="bluesky_link"
 							isLink
 							isPrimary
@@ -86,7 +86,7 @@ const BlueSky = () => {
 						<div className="product-card__call-to-action">
 							<Button
 								className="media-block__button"
-								href="https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky"
+								href={getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky')}
 								utmContent="bluesky_link"
 								isLink
 								isPrimary
@@ -119,7 +119,7 @@ const BlueSky = () => {
 						<div className="product-card__call-to-action">
 							<Button
 								className="media-block__button"
-								href="https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky"
+								href={getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky')}
 								utmContent="bluesky_link"
 								isLink
 								isPrimary
@@ -158,7 +158,7 @@ const BlueSky = () => {
 						<div className="product-card__call-to-action">
 							<Button
 								className="media-block__button"
-								href="https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky"
+								href={getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky')}
 								utmContent="bluesky_link"
 								isLink
 								isPrimary

--- a/src/app/pages/home/sections.js
+++ b/src/app/pages/home/sections.js
@@ -4,6 +4,7 @@ import { BWAHeading, BWAButton } from '@app/components/atoms';
 import { BWAContentList, BWAContentListRow } from '@app/components/molecules';
 import { __ } from '@wordpress/i18n';
 import { JetpackLogo } from '@app/assets';
+import { getPlatformBaseUrl } from '@app/functions';
 
 const baseUrl = select('bluehost/plugin').getAdminUrl();
 
@@ -135,7 +136,7 @@ export const HostingSection = () => {
             title={ __('Manage My Sites', 'bluehost-wordpress-plugin') }
             desc={ __('Manage your site from Bluehost\'s control panel. You can create backups, set security, and improve performance.', 'bluehost-wordpress-plugin') }>
             <BWAButton
-                href={ 'https://my.bluehost.com/hosting/app?lil=1#/sites' }
+                href={getPlatformBaseUrl('/hosting/app?lil=1#/sites')}
                 isSecondary
                 utmContent="home_hosting_mysites_link"
             >
@@ -150,7 +151,7 @@ export const HostingSection = () => {
             title={ __('Email', 'bluehost-wordpress-plugin') }
             desc={ __('Create email accounts, compose, send, and receive your email from your Bluehost control panel.', 'bluehost-wordpress-plugin') }>
             <BWAButton
-                href={ 'https://my.bluehost.com/hosting/app?lil=1#/email-office' }
+                href={getPlatformBaseUrl('/hosting/app?lil=1#/email-office')}
                 isSecondary
                 utmContent="home_hosting_email_link"
             >
@@ -165,7 +166,7 @@ export const HostingSection = () => {
             title={ __('Domains', 'bluehost-wordpress-plugin') }
             desc={ __('Find a new domain and assign it to your site or start a new site with a fresh domain.', 'bluehost-wordpress-plugin') }>
             <BWAButton
-                href={ 'https://my.bluehost.com/hosting/app?lil=1#/domains' }
+                href={getPlatformBaseUrl('/hosting/app?lil=1#/domains')}
                 isSecondary
                 utmContent="home_hosting_find_domain_link"
             >
@@ -180,7 +181,7 @@ export const HostingSection = () => {
             title={ __('Help', 'bluehost-wordpress-plugin') }
             desc={ __('Get help from Bluehost’s U.S.-based award-winning support team. It’s available 24/7 through phone and chat.', 'bluehost-wordpress-plugin') }>
             <BWAButton
-                href={ 'https://my.bluehost.com/hosting/help' }
+                href={getPlatformBaseUrl('/hosting/help')}
                 isSecondary
                 utmContent="home_hosting_help_link"
             >

--- a/src/app/pages/marketplace/services/index.js
+++ b/src/app/pages/marketplace/services/index.js
@@ -3,6 +3,7 @@ import { BWAProductCard } from '@app/components/molecules';
 import { useMojoApi } from '@app/hooks';
 import { withRouter } from 'react-router-dom';
 import { __ } from '@wordpress/i18n';
+import { getPlatformBaseUrl } from '@app/functions';
 
 function ServicesPage( { history } ) {
 	const [ { done, isError, isLoading, payload } ] = useMojoApi( 'services', { category: '', count: 1000 } );
@@ -14,7 +15,7 @@ function ServicesPage( { history } ) {
 	if ( payload.hasOwnProperty('items') ) {
 		payload.items.unshift({
 			id: 'blue-sky',
-			'buy_url': 'https://my.bluehost.com/cgi/app/#/marketplace/product/i/bluesky?utm_term=Get%20Started&utm_content=bluesky_link&utm_campaign=&utm_source=wp-admin%2Fadmin.php%3Fpage%3Dbluehost%23%2Fmarketplace%2Fservices&utm_medium=bluehost_plugin',
+			'buy_url': getPlatformBaseUrl('/cgi/app/#/marketplace/product/i/bluesky?utm_term=Get%20Started&utm_content=bluesky_link&utm_campaign=&utm_source=wp-admin%2Fadmin.php%3Fpage%3Dbluehost%23%2Fmarketplace%2Fservices&utm_medium=bluehost_plugin'),
 			images: {
 				'preview_url': 'https://cdn.hiive.space/bluehost/blue-sky-product-banner.png'
 			},


### PR DESCRIPTION
## Proposed changes

* Create `getPlatformBaseUrl()` in `@app/functions` to return the proper root URL for the Bluehost Platform.
* Swap direct references for `my.bluehost.com` to use new helper function

This is a first step towards better multi-brand support in the admin application. URL references now will dynamically swap for Bluehost India's my cluster.

I spun up a Bluehost India account to validate URLs are valid in both platforms.

## Type of Change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
