### PR TITLE
Conditionally load wp-admin/includes/misc.php only when we need to

### DIFF
--- a/inc/RestApi/SettingsController.php
+++ b/inc/RestApi/SettingsController.php
@@ -123,9 +123,6 @@ class SettingsController extends \WP_REST_Controller {
 						exec( "wp config set EMPTY_TRASH_DAYS $days --type=constant --raw" ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 						break;
 					case 'cacheLevel':
-						// Include misc.php because the cache level update requires save_mod_rewrite_rules()
-						// This should probably be moved to the Endurance Page Cache plugin later
-						include 'wp-admin/includes/misc.php';
 						update_option( 'endurance_cache_level', $new_value );
 						break;
 					case 'hasSetHomepage':

--- a/inc/cli/cache.php
+++ b/inc/cli/cache.php
@@ -179,9 +179,9 @@ class BH_WP_CLI_Cache extends BH_WP_CLI_Command {
 	/**
 	 * Use WordPress HTTP Library to Retrieve Single-File Drop-In Plugin from GitHub Repository
 	 *
-	 * @param $url
-	 * @param $filename
-	 * @param string   $dir
+	 * @param        $url
+	 * @param        $filename
+	 * @param string $dir
 	 *
 	 * @throws \WP_CLI\ExitException
 	 */
@@ -199,7 +199,9 @@ class BH_WP_CLI_Cache extends BH_WP_CLI_Command {
 			$file_contents = $response->body . '/**' . PHP_EOL . '* FILE CREATED VIA WP-CLI' . PHP_EOL . '* ' . current_time( 'mysql' ) . PHP_EOL . '*/' . PHP_EOL;
 			file_put_contents( $dir . $filename, $file_contents );
 			if ( file_exists( $dir . $filename ) ) {
-				save_mod_rewrite_rules();
+				if ( ! function_exists( 'save_mod_rewrite_rules' ) ) {
+					save_mod_rewrite_rules();
+				}
 				$this->success( ucfirst( $this->current_type ) . ' Cache placed in /mu-plugins/' . $filename . '. It\'s active!' );
 			} else {
 				$this->error( 'Couldn\'t write ' . $this->current_type . ' cache file to ' . $dir );
@@ -239,7 +241,9 @@ class BH_WP_CLI_Cache extends BH_WP_CLI_Command {
 	private function remove_mu_plugin() {
 		if ( file_exists( $this->current_plugin_path ) ) {
 			if ( unlink( $this->current_plugin_path ) ) {
-				save_mod_rewrite_rules();
+				if ( ! function_exists( 'save_mod_rewrite_rules' ) ) {
+					save_mod_rewrite_rules();
+				}
 				$this->success( ucfirst( $this->current_type ) . ' caching disabled.' );
 			} else {
 				$this->error( 'Failed to remove ' . ucfirst( $this->current_type ) . ' cache file from ' . static::$mu_plugin_dir );

--- a/inc/cli/cache.php
+++ b/inc/cli/cache.php
@@ -200,8 +200,9 @@ class BH_WP_CLI_Cache extends BH_WP_CLI_Command {
 			file_put_contents( $dir . $filename, $file_contents );
 			if ( file_exists( $dir . $filename ) ) {
 				if ( ! function_exists( 'save_mod_rewrite_rules' ) ) {
-					save_mod_rewrite_rules();
+					include ABSPATH . 'wp-admin/includes/misc.php';
 				}
+				save_mod_rewrite_rules();
 				$this->success( ucfirst( $this->current_type ) . ' Cache placed in /mu-plugins/' . $filename . '. It\'s active!' );
 			} else {
 				$this->error( 'Couldn\'t write ' . $this->current_type . ' cache file to ' . $dir );
@@ -242,8 +243,9 @@ class BH_WP_CLI_Cache extends BH_WP_CLI_Command {
 		if ( file_exists( $this->current_plugin_path ) ) {
 			if ( unlink( $this->current_plugin_path ) ) {
 				if ( ! function_exists( 'save_mod_rewrite_rules' ) ) {
-					save_mod_rewrite_rules();
+					include ABSPATH . 'wp-admin/includes/misc.php';
 				}
+				save_mod_rewrite_rules();
 				$this->success( ucfirst( $this->current_type ) . ' caching disabled.' );
 			} else {
 				$this->error( 'Failed to remove ' . ucfirst( $this->current_type ) . ' cache file from ' . static::$mu_plugin_dir );


### PR DESCRIPTION
## Proposed changes

Update file loading of wp-admin/includes/misc.php to only load when necessary. If something else (e.g. EPC) has already loaded the file, the result is an error.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
