### PR TITLE
update AccessToken class to store user_id as well

### DIFF
--- a/inc/AccessToken.php
+++ b/inc/AccessToken.php
@@ -66,6 +66,7 @@ class AccessToken {
 	 *
 	 * @param string $token      Access token
 	 * @param int    $expiration Timestamp of expiration
+	 * @param int    $user_id WordPress user id
 	 */
 	public static function set_token( $token, $expiration, $user_id ) {
 		update_option( 'bluehost_access_token', $token, true );


### PR DESCRIPTION
## Proposed changes

Store the user_id which is returned when requesting a token. This is a missing piece to be able to call certain endpoints, so once we store the id, it can then be used to construct API calls where it is required.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I wonder if checking expiration is helpful here. I know it'd be more simple to just return the user here, but should we check that the token isn't expired to ensure that the user_id will be useful? Probably overthinking it here. Thoughts?
