### PR TITLE
Use client-side request to prime notices transient

### DIFF
--- a/inc/Notifications/AdminNotices.php
+++ b/inc/Notifications/AdminNotices.php
@@ -53,7 +53,7 @@ class AdminNotices {
 		}
 
 		$page          = str_replace( admin_url(), '', Url::getCurrentUrl() );
-		$notifications = new NotificationsRepository();
+		$notifications = new NotificationsRepository( false );
 		$collection    = $notifications->collection();
 		if ( $collection->count() ) {
 			$collection->each(

--- a/inc/Notifications/NotificationsApi.php
+++ b/inc/Notifications/NotificationsApi.php
@@ -50,7 +50,7 @@ class NotificationsApi {
 					'context' => array(
 						'required'          => true,
 						'validate_callback' => function ( $value ) {
-							return is_string( $value ) && in_array( $value, array( 'bluehost-plugin', 'wp-admin-notice' ), true );
+							return is_string( $value ) && in_array( $value, array( 'bluehost-plugin', 'wp-admin-notice', 'wp-admin-prime' ), true );
 						},
 					),
 					'page'    => array(

--- a/inc/Notifications/NotificationsRepository.php
+++ b/inc/Notifications/NotificationsRepository.php
@@ -27,12 +27,14 @@ class NotificationsRepository {
 
 	/**
 	 * NotificationsRepository constructor.
+	 *
+	 * @param boolean $fetch_notices When true (default), requests notices immediately. When false, loads script to prime transient client-side.
 	 */
-	public function __construct() {
+	public function __construct( $fetch_notices = true ) {
 
 		$notifications = get_transient( self::TRANSIENT );
 
-		if ( false === $notifications ) {
+		if ( false === $notifications && true === $fetch_notices ) {
 			$response = wp_remote_get(
 				BH_HUB_URL . '/notifications',
 				array(
@@ -51,6 +53,14 @@ class NotificationsRepository {
 					set_transient( self::TRANSIENT, $notifications, 5 * MINUTE_IN_SECONDS );
 				}
 			}
+		} elseif ( false === $notifications && false === $fetch_notices ) {
+			wp_enqueue_script(
+				'newfold-notices-primer',
+				plugins_url( 'inc/Notifications/js/prime-notices.js', BLUEHOST_PLUGIN_FILE ),
+				array('wp-dom-ready', 'wp-api-fetch'),
+				BLUEHOST_PLUGIN_VERSION,
+				true
+			);
 		}
 
 		$notifications = is_array( $notifications ) ? $notifications : array();

--- a/inc/Notifications/NotificationsRepository.php
+++ b/inc/Notifications/NotificationsRepository.php
@@ -57,7 +57,7 @@ class NotificationsRepository {
 			wp_enqueue_script(
 				'newfold-notices-primer',
 				plugins_url( 'inc/Notifications/js/prime-notices.js', BLUEHOST_PLUGIN_FILE ),
-				array('wp-dom-ready', 'wp-api-fetch'),
+				array( 'wp-dom-ready', 'wp-api-fetch' ),
 				BLUEHOST_PLUGIN_VERSION,
 				true
 			);

--- a/inc/Notifications/js/prime-notices.js
+++ b/inc/Notifications/js/prime-notices.js
@@ -4,7 +4,7 @@ const apiFetch = wp.apiFetch;
 const primeTransient = () => apiFetch({ path: '/bluehost/v1/notifications?context=wp-admin-prime'});
 
 if ('requestIdleCallback' in window) {
-    window.requestIdleCallback(primeTransient, { timeout: 2500 })
+    window.requestIdleCallback(primeTransient, { timeout: 2500 });
 } else {
     domReady(primeTransient);
 }

--- a/inc/Notifications/js/prime-notices.js
+++ b/inc/Notifications/js/prime-notices.js
@@ -1,0 +1,3 @@
+const domReady = wp.domReady;
+const apiFetch = wp.apiFetch;
+domReady(() => apiFetch({ path: '/bluehost/v1/notifications?context=wp-admin-prime'}));

--- a/inc/Notifications/js/prime-notices.js
+++ b/inc/Notifications/js/prime-notices.js
@@ -1,3 +1,10 @@
 const domReady = wp.domReady;
 const apiFetch = wp.apiFetch;
-domReady(() => apiFetch({ path: '/bluehost/v1/notifications?context=wp-admin-prime'}));
+
+const primeTransient = () => apiFetch({ path: '/bluehost/v1/notifications?context=wp-admin-prime'});
+
+if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(primeTransient, { timeout: 2500 })
+} else {
+    domReady(primeTransient);
+}


### PR DESCRIPTION
## Proposed changes

When `get_transient('bluehost_notifications')` returns `false`, instead of making request in PHP that impacts runtime, load tiny `prime-notices.js` file to hit endpoint that will make request.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
