### PR TITLE
fix jetpack coming soon subscribe submission

### DIFF
--- a/inc/coming-soon.php
+++ b/inc/coming-soon.php
@@ -90,10 +90,13 @@ function mojo_coming_soon_subscribe() {
 			// Initialize JetPack_Subscriptions
 			$jetpack = Jetpack_Subscriptions::init();
 			// Get JetPack response and subscribe email if response is true
-			$response = $jetpack->subscribe( $email, 0, false,
+			$response = $jetpack->subscribe( 
+				$email,
+				0,
+				false,
 				// See Jetpack subscribe `extra_data` attribute
 				array(
-					'server_data'    => jetpack_subscriptions_cherry_pick_server_data(),
+					'server_data' => jetpack_subscriptions_cherry_pick_server_data(),
 				)
 			);
 

--- a/inc/coming-soon.php
+++ b/inc/coming-soon.php
@@ -90,7 +90,7 @@ function mojo_coming_soon_subscribe() {
 			// Initialize JetPack_Subscriptions
 			$jetpack = Jetpack_Subscriptions::init();
 			// Get JetPack response and subscribe email if response is true
-			$response = $jetpack->subscribe( 
+			$response = $jetpack->subscribe(
 				$email,
 				0,
 				false,

--- a/inc/coming-soon.php
+++ b/inc/coming-soon.php
@@ -80,9 +80,6 @@ function mojo_coming_soon_subscribe() {
 
 	} else {
 
-		// Initialize JetPack_Subscriptions
-		$jetpack = Jetpack_Subscriptions::init();
-
 		if ( ! is_email( $email ) ) {
 
 			$a_response['message'] = __( 'Please provide a valid email address', 'bluehost-wordpress-plugin' );
@@ -90,8 +87,15 @@ function mojo_coming_soon_subscribe() {
 
 		} else {
 
+			// Initialize JetPack_Subscriptions
+			$jetpack = Jetpack_Subscriptions::init();
 			// Get JetPack response and subscribe email if response is true
-			$response = $jetpack->subscribe( $email, 0, false );
+			$response = $jetpack->subscribe( $email, 0, false,
+				// See Jetpack subscribe `extra_data` attribute
+				array(
+					'server_data'    => jetpack_subscriptions_cherry_pick_server_data(),
+				)
+			);
 
 			if ( isset( $response[0]->errors ) ) {
 


### PR DESCRIPTION
## Proposed changes

Bringing in a fix for jetpack subscribe functionality on the coming soon page. I spotted that this form was always failing when building the HG plugin and traced it down to a missing parameter. This commit adds the missing parameter and I've tested on a few sites that it does in fact fix the failing jetpack subscribe. 

I don't know how frequently this is used, but with the number of sites we have running the plugin, it's safe to say there are more than a handful.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
