### PR TITLE
Pass correct parameter to dismiss notification method

### DIFF
--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -18,6 +18,9 @@
 			return response.json();
 		}).then( data => {
 			if (data.content) {
+				if (purchaseStatus) {
+					dismissNotice(e);
+				}
 				modalWindow.innerHTML = data.content;
 			} else {
 				displayError(modalWindow, "purchase");
@@ -84,9 +87,6 @@
 
 	const closeModal = (e) => {
 		ctbmodal.destroy();
-		if (purchaseStatus){
-			dismissNotice(e);
-		}
 	}
 
 	const displayError = (modalWindow, error) => {

--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -19,7 +19,7 @@
 		}).then( data => {
 			if (data.content) {
 				if (purchaseStatus) {
-					dismissNotice(e);
+					dismissNotice(modalWindow);
 				}
 				modalWindow.innerHTML = data.content;
 			} else {


### PR DESCRIPTION
This fixes an issue where on a successful purchase we were passing an event object instead of a node to the `dismissNotice()` method and it was throwing an error. 