### PR TITLE
Pass the correct object to dissmissNotice method

### DIFF
--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -19,7 +19,7 @@
 		}).then( data => {
 			if (data.content) {
 				if (purchaseStatus) {
-					dismissNotice(e);
+					dismissNotice(modalWindow);
 				}
 				modalWindow.innerHTML = data.content;
 			} else {


### PR DESCRIPTION
This fixes an issue where on a successful purchase we were passing an event object instead of a node to the `dismissNotice()` method and it was throwing an error. 