### PR TITLE
Add check for iconv() existence

### DIFF
--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Bluehost
  * Description: This plugin integrates your WordPress site with the Bluehost control panel, including performance, security, and update features.
- * Version: 2.11.1
+ * Version: 2.11.2
  * Tested up to: 6.0.1
  * Requires at least: 4.7
  * Requires PHP: 7.0
@@ -32,7 +32,7 @@ if ( defined( 'BLUEHOST_PLUGIN_VERSION' ) ) {
 }
 
 // Define constants
-define( 'BLUEHOST_PLUGIN_VERSION', '2.11.1' );
+define( 'BLUEHOST_PLUGIN_VERSION', '2.11.2' );
 define( 'BLUEHOST_PLUGIN_FILE', __FILE__ );
 define( 'BLUEHOST_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLUEHOST_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/inc/SiteMeta.php
+++ b/inc/SiteMeta.php
@@ -39,7 +39,11 @@ class SiteMeta {
 		static $id = null;
 		if ( is_null( $id ) ) {
 			$path = self::get_path();
-			$id   = bin2hex( iconv( mb_detect_encoding( $path, mb_detect_order(), true ), 'UTF-8', $path ) );
+			if ( function_exists( 'iconv' ) ) {
+				$id = bin2hex( iconv( mb_detect_encoding( $path, mb_detect_order(), true ), 'UTF-8', $path ) );
+			} else {
+				$id = bin2hex( $path );
+			}
 		}
 
 		return $id;


### PR DESCRIPTION
Some VPS servers appear to have `iconv` disabled or not installed at all. When it is not available, we can fall back to just a plain `bin2hex()` call to calculate the `site_id`. 

This would handle fewer directory name encoding edge cases, but should prevent what appears to be a more broad issue. It's also [how we used to handle it](https://github.com/bluehost/bluehost-wordpress-plugin/blob/997ca344f29d00a697f1e4a838d112f3c96614ef/inc/base.php#L148) before the `SiteMeta::get_id()` method was created.