### PR TITLE
Fix CTB notification dismissal bug

### DIFF
--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Bluehost
  * Description: This plugin integrates your WordPress site with the Bluehost control panel, including performance, security, and update features.
- * Version: 2.11.4
+ * Version: 2.11.5
  * Tested up to: 6.0.1
  * Requires at least: 4.7
  * Requires PHP: 7.0
@@ -32,7 +32,7 @@ if ( defined( 'BLUEHOST_PLUGIN_VERSION' ) ) {
 }
 
 // Define constants
-define( 'BLUEHOST_PLUGIN_VERSION', '2.11.4' );
+define( 'BLUEHOST_PLUGIN_VERSION', '2.11.5' );
 define( 'BLUEHOST_PLUGIN_FILE', __FILE__ );
 define( 'BLUEHOST_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLUEHOST_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/inc/CTB/bootstrap.php
+++ b/inc/CTB/bootstrap.php
@@ -28,3 +28,10 @@ add_action(
 		);
 	}
 );
+
+add_action(
+	'admin_notices',
+	function () {
+		echo "<div id='nfd-ctb-container' aria-hidden='true'></div>";
+	}
+);

--- a/inc/CTB/ctb.css
+++ b/inc/CTB/ctb.css
@@ -2,11 +2,11 @@ body.noscroll {
 	overflow-y: hidden;
 }
 
-#ctb-modal-container {
+#nfd-ctb-container {
 	position: absolute;
 }
 
-#ctb-modal-container,
+#nfd-ctb-container,
 .ctb-modal-overlay {
 	position: fixed;
 	top: 0;
@@ -15,14 +15,14 @@ body.noscroll {
 	left: 0;
 }
 
-#ctb-modal-container {
+#nfd-ctb-container {
    z-index: 100000;
    display: flex;
    justify-content: center;
    align-items: center;
 }
 
-#ctb-modal-container[aria-hidden='true'] {
+#nfd-ctb-container[aria-hidden='true'] {
 	display: none;
 }
 

--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -111,7 +111,7 @@
 		if (notice) {
 			notice.parentNode.removeChild(notice);
 			window.fetch(
-				`${ window.nfdNotifications.restApiUrl }bluehost/v1/notifications/${ ctbId }`,
+				`${ window.nfdNotifications.restApiUrl }bluehost/v1/notifications/${ notice.dataset.id }`,
 				{
 					credentials: 'same-origin',
 					method: 'DELETE',

--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -1,9 +1,10 @@
 {
 	const purchase = (e) => {
 		let modalWindow = e.target.closest('.ctb-modal-content');
+		let ctbId = e.target.getAttribute('data-ctb-id');
 		e.target.closest('.ctb-actions').innerHTML = '<div class="ctb-loader"></div>';
 		window.fetch(
-			`${ window.nfdNotifications.restApiUrl }bluehost/v1/ctb/${ e.target.getAttribute('data-ctb-id') }`,
+			`${ window.nfdNotifications.restApiUrl }bluehost/v1/ctb/${ ctbId }`,
 			{
 				credentials: 'same-origin',
 				method: 'POST',
@@ -18,10 +19,10 @@
 			return response.json();
 		}).then( data => {
 			if (data.content) {
-				if (purchaseStatus) {
-					dismissNotice(modalWindow);
-				}
 				modalWindow.innerHTML = data.content;
+				if (purchaseStatus){
+					dismissNotice(ctbId);
+				}
 			} else {
 				displayError(modalWindow, "purchase");
 			}
@@ -53,9 +54,7 @@
 	}
 
 	const openModal = (e) => {
-		let el = document.createElement('div');
-		el.setAttribute('id', 'ctb-modal-container');
-		el.innerHTML = `
+		let modalContent = `
 		<div class="ctb-modal">
 			<div class="ctb-modal-overlay" data-a11y-dialog-destroy></div>
 			<div role="document" class="ctb-modal-content">
@@ -63,16 +62,24 @@
 			</div>
 		</div>
 		`;
-		e.target.insertAdjacentElement('afterend', el);
+		let ctbContainer = document.getElementById('nfd-ctb-container');
+		if (ctbContainer) {
+			ctbContainer.innerHTML = modalContent
+		} else {
+			ctbContainer = document.createElement('div');
+			ctbContainer.setAttribute('id', 'nfd-ctb-container');
+			ctbContainer.innerHTML = modalContent;
+			ctbContainer.target.insertAdjacentElement('afterend', nfd-ctb-container);
+		}
 
-		ctbmodal = new A11yDialog(el);
+		ctbmodal = new A11yDialog(ctbContainer);
 		ctbmodal.show();
 
 		purchaseStatus = false;
 
 		document.querySelector('body').classList.toggle('noscroll');
 
-		el.addEventListener('click', function(event) {
+		ctbContainer.addEventListener('click', function(event) {
 			if (event.target.dataset.action === 'purchase-ctb') {
 				purchase(event);
 			}
@@ -82,7 +89,7 @@
 			}
 		});
 
-		return el;
+		return ctbContainer;
 	}
 
 	const closeModal = (e) => {
@@ -97,13 +104,14 @@
 		</div>`;
 	}
 
-	const dismissNotice = (e) => {
-		const notice = e.closest('.bluehost-notice');
+	const dismissNotice = (ctbId) => {
+		const selector = '[data-ctb-id="' + ctbId + '"]';
+		const ctbTrigger = document.querySelector(selector)
+		const notice = ctbTrigger.closest('.bluehost-notice');
 		if (notice) {
-			const id = notice.getAttribute('data-id');
 			notice.parentNode.removeChild(notice);
 			window.fetch(
-				`${ window.nfdNotifications.restApiUrl }bluehost/v1/notifications/${ id }`,
+				`${ window.nfdNotifications.restApiUrl }bluehost/v1/notifications/${ ctbId }`,
 				{
 					credentials: 'same-origin',
 					method: 'DELETE',

--- a/inc/CTB/js/ctb.js
+++ b/inc/CTB/js/ctb.js
@@ -105,8 +105,7 @@
 	}
 
 	const dismissNotice = (ctbId) => {
-		const selector = '[data-ctb-id="' + ctbId + '"]';
-		const ctbTrigger = document.querySelector(selector)
+		const ctbTrigger = document.querySelector('[data-ctb-id="' + ctbId + '"]')
 		const notice = ctbTrigger.closest('.bluehost-notice');
 		if (notice) {
 			notice.parentNode.removeChild(notice);


### PR DESCRIPTION
This fixes an issue where CTB success messages were disappearing immediately upon creation while trying to remove the associated notification element. 

This separates CTB modals into their own container and targets the correct notification for dismissal by searching up the DOM tree for the notification that contains the CTB trigger. 