### PR TITLE
Remove WP Admin Notices on Bluehost pages

### DIFF
--- a/inc/admin-page-notifications-blocker.php
+++ b/inc/admin-page-notifications-blocker.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * Class containing functions for blocking WP admin notices and notifications on Bluehost pages.
+ *
+ * @package BluehostWordPressPlugin
+ */
 
 /**
- * Only run on bluehost pages
+ * Only run on Bluehost pages
  */
 if ( ! is_admin()
 	|| ! isset( $_GET['page'] )
@@ -17,24 +22,24 @@ class BH_Admin_Page_Notifications_Blocker {
 	/**
 	 * BH_Admin_Page_Notifications_Blocker constructor.
 	 */
-	function __construct() {
-		add_action('admin_head', array( $this, 'remove_admin_notices_on_bluehost_pages' ), 99);
+	public function __construct() {
+		add_action( 'admin_head', array( $this, 'remove_admin_notices_on_bluehost_pages' ), 99 );
 		add_action( 'admin_print_styles', array( $this, 'remove_notifications_on_bluehost_pages' ) );
 	}
 
 	/**
 	 * Remove WP admin notices.
 	 */
-	function remove_admin_notices_on_bluehost_pages() {
+	public function remove_admin_notices_on_bluehost_pages() {
 		remove_all_actions( 'all_admin_notices' );
-		remove_all_actions	( 'admin_notices' );
+		remove_all_actions( 'admin_notices' );
 		remove_all_actions( 'user_admin_notices' );
 	}
 
 	/**
 	 * Target notices using highly-specific CSS selectors to avoid collisions.
 	 */
-	function remove_notifications_on_bluehost_pages() {
+	public function remove_notifications_on_bluehost_pages() {
 		if ( ! isset( $_GET['page'] ) || false === stripos( filter_input( INPUT_GET, 'page' ), 'bluehost' ) ) {
 			return;
 		}

--- a/inc/admin-page-notifications-blocker.php
+++ b/inc/admin-page-notifications-blocker.php
@@ -18,7 +18,17 @@ class BH_Admin_Page_Notifications_Blocker {
 	 * BH_Admin_Page_Notifications_Blocker constructor.
 	 */
 	function __construct() {
+		add_action('admin_head', array( $this, 'remove_admin_notices_on_bluehost_pages' ), 99);
 		add_action( 'admin_print_styles', array( $this, 'remove_notifications_on_bluehost_pages' ) );
+	}
+
+	/**
+	 * Remove WP admin notices.
+	 */
+	function remove_admin_notices_on_bluehost_pages() {
+		remove_all_actions( 'all_admin_notices' );
+		remove_all_actions	( 'admin_notices' );
+		remove_all_actions( 'user_admin_notices' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

* Add remove_all_actions for all_admin_notices, admin_notices, and user_admin_notices with high specificity to override other calls.

* Kept CSS script to count for notices that get injected after DOM load.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
