### PR TITLE
Disable Yoast SEO onboarding redirect

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -53,6 +53,17 @@ AdminBar::init();
 BuildAssets::init();
 LoginRedirect::init();
 
+// Disable Yoast SEO onboarding redirect
+add_action(
+	'admin_init',
+	function () {
+		if ( class_exists( 'WPSEO_Options' ) ) {
+			WPSEO_Options::set( 'should_redirect_after_install_free', false );
+		}
+	},
+	2
+);
+
 // Require files
 require __DIR__ . '/inc/admin.php';
 require __DIR__ . '/inc/admin-page-notifications-blocker.php';


### PR DESCRIPTION
## Proposed changes

Bluehost's SSO functionality doesn't work on the first try because Yoast SEO is redirecting to their onboarding before the login actually occurs. Subsequent attempts to SSO work because the Yoast onboarding page has already been "hit" (option saved in the database even though the user never saw it because they ended up at a login screen).

This PR disables that redirect to prevent this SSO issue.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
