### PR TITLE
Add/replay meta

### DIFF
--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Run Cypress Tests
         uses: replayio/action-cypress@v0.2.4
         if: ${{ github.repository == 'bluehost/bluehost-wordpress-plugin' }}
+        env:
+          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: "php-${{ matrix.phpVersion }}, wp-${{ matrix.wpVersion }}"
         with:
           api-key: ${{ secrets.RECORD_REPLAY_API_KEY }}
           browser: 'Replay Chromium'


### PR DESCRIPTION
## Proposed changes

Currently, when we run the full test matrix, we end up with duplicate runs in Replay and no way to tell which replays were for which versions of WP and PHP. This PR adds the ability to label replays.
