### PR TITLE
Add/show block themes only when browsing popular themes

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,6 +3,7 @@
 use Bluehost\AdminBar;
 use Bluehost\BuildAssets;
 use Bluehost\LoginRedirect;
+use Bluehost\Themes;
 use WP_Forge\WPUpdateHandler\PluginUpdater;
 use WP_Forge\UpgradeHandler\UpgradeHandler;
 
@@ -55,6 +56,7 @@ if ( is_admin() ) {
 AdminBar::init();
 BuildAssets::init();
 LoginRedirect::init();
+Themes::init();
 
 // Disable Yoast SEO onboarding redirect
 add_action(

--- a/inc/Themes.php
+++ b/inc/Themes.php
@@ -6,7 +6,7 @@ namespace Bluehost;
  * Class Themes
  *
  * themes.php and theme-install.php related customizations.
- * 
+ *
  * @package Bluehost
  */
 class Themes {
@@ -14,24 +14,26 @@ class Themes {
 	/**
 	 * List of block themes to show on top of the themes popula tab results.
 	 * Must be a valid "theme-slug"
-	 * 
+	 *
 	 * @var array
 	 */
-	public static $priorityThemes = [ 'yith-wonder' ];
+	public static $priority_themes = array(
+		'yith-wonder'
+	);
 
 	/**
 	 * Initialize themes.php and theme-install.php related customizations.
 	 */
 	public static function init() {
 		add_action( 'admin_head-theme-install.php', array( __CLASS__, 'append_premuim_themes_tab' ) );
-		add_filter( 'themes_api_args',  array( __CLASS__, 'query_block_themes_args' ), 10, 2 );
+		add_filter( 'themes_api_args', array( __CLASS__, 'query_block_themes_args' ), 10, 2 );
 		add_filter( 'themes_api_result', array( __CLASS__, 'sort_query_themes_results' ), 10, 3 );
 		// add_action( 'admin_head-theme-install.php', array( __CLASS__, 'recommended_theme_ribbon' ) );
 	}
-	
+
 	/**
-	* Add premium Marketplace themes link (as a tab) to the themes browser.
-	*/
+	 * Add premium Marketplace themes link (as a tab) to the themes browser.
+	 */
 	public static function append_premuim_themes_tab() {
 		?>
 
@@ -39,7 +41,7 @@ class Themes {
 		window.addEventListener('DOMContentLoaded', () => {
 			const themesFilterContainer = document.querySelector('.wp-filter .filter-links');
 			const bluehostPremiumThemesLink = document.createElement('li');
-			
+
 			bluehostPremiumThemesLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace/themes\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
 			themesFilterContainer.appendChild(bluehostPremiumThemesLink);
 		});
@@ -50,13 +52,13 @@ class Themes {
 
 	/**
 	 * Filters query arguments to only retrieve block themes (full-site-editing) from the WordPress.org Themes API.
-	 * 
+	 *
 	 *  @since 2.8.0
 	 *
 	 * @param object $args   Arguments used to query for installer pages from the WordPress.org Themes API.
 	 * @param string $action Requested action. Likely values are 'theme_information',
 	 *                       'feature_list', or 'query_themes'.
-	 * 
+	 *
 	 * @return object updated $args for this request.
 	 */
 	public static function query_block_themes_args( $args, $action ) {
@@ -66,19 +68,19 @@ class Themes {
 				$page = $args->page;
 			}
 
-			$args = ( object ) [
-				'tag' => 'full-site-editing',
+			$args = (object) array(
+				'tag'      => 'full-site-editing',
 				'per_page' => 30,
-				'page' => $page,
-				'browse' => 'popular'
-			];
+				'page'     => $page,
+				'browse'   => 'popular',
+			);
 		}
 
 		return $args;
 	}
 
 	/**
-	 * Sorts the returned WordPress.org Themes API response to show self::$priorityThemes on top.
+	 * Sorts the returned WordPress.org Themes API response to show self::$priority_themes on top.
 	 *
 	 * @since 2.8.0
 	 *
@@ -86,25 +88,24 @@ class Themes {
 	 * @param string                  $action Requested action. Likely values are 'theme_information',
 	 *                                        'feature_list', or 'query_themes'.
 	 * @param stdClass                $args   Arguments used to query for installer pages from the WordPress.org Themes API.
-	 * 
-	 * @return stdClass $res sorted themes with self::$priorityThemes on top.
+	 *
+	 * @return stdClass $res sorted themes with self::$priority_themes on top.
 	 */
 	public static function sort_query_themes_results( $res, $action, $args ) {
 
 		if ( 'query_themes' === $action && 'popular' === $args->browse ) {
 
-			$themesToShowFirst = [];
+			$themes_to_show_first = [];
 			foreach ( $res->themes as $key => $theme ) {
-				if ( in_array( $theme->slug, self::$priorityThemes, true ) ) {
-					$themesToShowFirst[] = $theme;
+				if ( in_array( $theme->slug, self::$priority_themes, true ) ) {
+					$themes_to_show_first[] = $theme;
 
-					unset( $res->themes[$key] );
+					unset( $res->themes[ $key ] );
 				}
 			}
-			$sortedThemesResults = array_merge( $res->themes, $themesToShowFirst );
 
-			$sortedThemesResults = array_merge( $themesToShowFirst, $res->themes );
-			$res->themes = $sortedThemesResults;
+			$sorted_themes_res = array_merge( $themes_to_show_first, $res->themes );
+			$res->themes = $sorted_themes_res;
 		}
 
 		return $res;
@@ -136,14 +137,14 @@ class Themes {
 		<script type="text/javascript">
 			window.addEventListener('DOMContentLoaded', () => {
 
-				const priorityThemeslug = 'yith-wonder';
+				const recommendedThemeSlug = 'yith-wonder';
 				const themesContainer = document.querySelector('.theme-browser');
 
-				const themesLoaded = (mutationList, observer) => {
+				const themesHaveRendered = (mutationList, observer) => {
 					for (const mutation of mutationList) {
 						if (mutation.type === 'childList') {
 							const themes = document.querySelector('.theme-browser .themes');
-							const yithTheme = themesContainer.querySelector('.theme[data-slug="' + priorityThemeslug + '"]');
+							const yithTheme = themesContainer.querySelector('.theme[data-slug="' + recommendedThemeSlug + '"]');
 							if (yithTheme) {
 								yithTheme.classList.add('bluehost-recommended-theme');
 							}
@@ -151,7 +152,7 @@ class Themes {
 					}
 				}
 
-				const observer = new MutationObserver(themesLoaded);
+				const observer = new MutationObserver(themesHaveRendered);
 				observer.observe(themesContainer, {
 					childList: true,
 					subtree: true

--- a/inc/Themes.php
+++ b/inc/Themes.php
@@ -18,7 +18,7 @@ class Themes {
 	 * @var array
 	 */
 	public static $priority_themes = array(
-		'yith-wonder'
+		'yith-wonder',
 	);
 
 	/**
@@ -95,7 +95,8 @@ class Themes {
 
 		if ( 'query_themes' === $action && 'popular' === $args->browse ) {
 
-			$themes_to_show_first = [];
+			$themes_to_show_first = array();
+
 			foreach ( $res->themes as $key => $theme ) {
 				if ( in_array( $theme->slug, self::$priority_themes, true ) ) {
 					$themes_to_show_first[] = $theme;
@@ -105,7 +106,7 @@ class Themes {
 			}
 
 			$sorted_themes_res = array_merge( $themes_to_show_first, $res->themes );
-			$res->themes = $sorted_themes_res;
+			$res->themes       = $sorted_themes_res;
 		}
 
 		return $res;

--- a/inc/Themes.php
+++ b/inc/Themes.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Bluehost;
+
+/**
+ * Class Themes
+ *
+ * themes.php and theme-install.php related customizations.
+ * 
+ * @package Bluehost
+ */
+class Themes {
+
+    /**
+	 * List of block themes to show on top of the themes popula tab results.
+	 * Must be a valid "theme-slug"
+     * 
+	 * @var array
+	 */
+    public static $priorityThemes = [ 'yith-wonder' ];
+
+    /**
+     * Initialize themes.php and theme-install.php related customizations.
+     */
+    public static function init() {
+        add_action( 'admin_head-theme-install.php', array( __CLASS__, 'append_premuim_themes_tab' ) );
+        add_filter( 'themes_api_args',  array( __CLASS__, 'query_block_themes_args' ), 10, 2 );
+        add_filter( 'themes_api_result', array( __CLASS__, 'sort_query_themes_results' ), 10, 3 );
+        // add_action( 'admin_head-theme-install.php', array( __CLASS__, 'recommended_theme_ribbon' ) );
+    }
+    
+    /**
+    * Add premium Marketplace themes link (as a tab) to the themes browser.
+    */
+    public static function append_premuim_themes_tab() {
+        ?>
+
+        <script type="text/javascript">
+        window.addEventListener('DOMContentLoaded', () => {
+            const themesFilterContainer = document.querySelector('.wp-filter .filter-links');
+            const bluehostPremiumThemesLink = document.createElement('li');
+            
+            bluehostPremiumThemesLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace/themes\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
+            themesFilterContainer.appendChild(bluehostPremiumThemesLink);
+        });
+        </script>
+
+        <?php
+    }
+
+    /**
+     * Filters query arguments to only retrieve block themes (full-site-editing) from the WordPress.org Themes API.
+     * 
+     *  @since 2.8.0
+	 *
+	 * @param object $args   Arguments used to query for installer pages from the WordPress.org Themes API.
+	 * @param string $action Requested action. Likely values are 'theme_information',
+	 *                       'feature_list', or 'query_themes'.
+     * 
+     * @return object updated $args for this request.
+     */
+    public static function query_block_themes_args( $args, $action ) {
+
+        if ( 'query_themes' === $action && 'popular' === $args->browse ) {
+            if ( isset( $args->page ) ) {
+                $page = $args->page;
+            }
+
+            $args = ( object ) [
+                'tag' => 'full-site-editing',
+                'per_page' => 30,
+                'page' => $page,
+                'browse' => 'popular'
+            ];
+        }
+
+        return $args;
+    }
+
+    /**
+     * Sorts the returned WordPress.org Themes API response to show self::$priorityThemes on top.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param array|stdClass|WP_Error $res    WordPress.org Themes API response.
+	 * @param string                  $action Requested action. Likely values are 'theme_information',
+	 *                                        'feature_list', or 'query_themes'.
+	 * @param stdClass                $args   Arguments used to query for installer pages from the WordPress.org Themes API.
+     * 
+     * @return stdClass $res sorted themes with self::$priorityThemes on top.
+     */
+    public static function sort_query_themes_results( $res, $action, $args ) {
+
+        if ( 'query_themes' === $action && 'popular' === $args->browse ) {
+
+            $themesToShowFirst = [];
+            foreach ( $res->themes as $key => $theme ) {
+                if ( in_array( $theme->slug, self::$priorityThemes, true ) ) {
+                    $themesToShowFirst[] = $theme;
+
+                    unset( $res->themes[$key] );
+                }
+            }
+            $sortedThemesResults = array_merge( $res->themes, $themesToShowFirst );
+
+            $sortedThemesResults = array_merge( $themesToShowFirst, $res->themes );
+            $res->themes = $sortedThemesResults;
+        }
+
+        return $res;
+    }
+
+    /**
+     * Renders "Recommended" ribbon on the Yith Wonder theme card.
+     */
+    public static function recommended_theme_ribbon() {
+        ?>
+
+        <style>
+            .bluehost-recommended-theme {
+                box-shadow: 0 0 0 3px #a4acb9;
+            }
+
+            .bluehost-recommended-theme::after {
+                content: "Recommended";
+                position: absolute;
+                top: -15px;
+                right: 5%;
+                background-color: #355ed3;
+                color: white;
+                padding: 5px 10px;
+                border-radius: 1.5px;
+            }
+        </style>
+
+        <script type="text/javascript">
+            window.addEventListener('DOMContentLoaded', () => {
+
+                const priorityThemeslug = 'yith-wonder';
+                const themesContainer = document.querySelector('.theme-browser');
+
+                const themesLoaded = (mutationList, observer) => {
+                    for (const mutation of mutationList) {
+                        if (mutation.type === 'childList') {
+                            const themes = document.querySelector('.theme-browser .themes');
+                            const yithTheme = themesContainer.querySelector('.theme[data-slug="' + priorityThemeslug + '"]');
+                            if (yithTheme) {
+                                yithTheme.classList.add('bluehost-recommended-theme');
+                            }
+                        }
+                    }
+                }
+
+                const observer = new MutationObserver(themesLoaded);
+                observer.observe(themesContainer, {
+                    childList: true,
+                    subtree: true
+                });
+
+            });
+        </script>
+
+        <?php
+    }
+}

--- a/inc/Themes.php
+++ b/inc/Themes.php
@@ -11,74 +11,74 @@ namespace Bluehost;
  */
 class Themes {
 
-    /**
+	/**
 	 * List of block themes to show on top of the themes popula tab results.
 	 * Must be a valid "theme-slug"
-     * 
+	 * 
 	 * @var array
 	 */
-    public static $priorityThemes = [ 'yith-wonder' ];
+	public static $priorityThemes = [ 'yith-wonder' ];
 
-    /**
-     * Initialize themes.php and theme-install.php related customizations.
-     */
-    public static function init() {
-        add_action( 'admin_head-theme-install.php', array( __CLASS__, 'append_premuim_themes_tab' ) );
-        add_filter( 'themes_api_args',  array( __CLASS__, 'query_block_themes_args' ), 10, 2 );
-        add_filter( 'themes_api_result', array( __CLASS__, 'sort_query_themes_results' ), 10, 3 );
-        // add_action( 'admin_head-theme-install.php', array( __CLASS__, 'recommended_theme_ribbon' ) );
-    }
-    
-    /**
-    * Add premium Marketplace themes link (as a tab) to the themes browser.
-    */
-    public static function append_premuim_themes_tab() {
-        ?>
+	/**
+	 * Initialize themes.php and theme-install.php related customizations.
+	 */
+	public static function init() {
+		add_action( 'admin_head-theme-install.php', array( __CLASS__, 'append_premuim_themes_tab' ) );
+		add_filter( 'themes_api_args',  array( __CLASS__, 'query_block_themes_args' ), 10, 2 );
+		add_filter( 'themes_api_result', array( __CLASS__, 'sort_query_themes_results' ), 10, 3 );
+		// add_action( 'admin_head-theme-install.php', array( __CLASS__, 'recommended_theme_ribbon' ) );
+	}
+	
+	/**
+	* Add premium Marketplace themes link (as a tab) to the themes browser.
+	*/
+	public static function append_premuim_themes_tab() {
+		?>
 
-        <script type="text/javascript">
-        window.addEventListener('DOMContentLoaded', () => {
-            const themesFilterContainer = document.querySelector('.wp-filter .filter-links');
-            const bluehostPremiumThemesLink = document.createElement('li');
-            
-            bluehostPremiumThemesLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace/themes\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
-            themesFilterContainer.appendChild(bluehostPremiumThemesLink);
-        });
-        </script>
+		<script type="text/javascript">
+		window.addEventListener('DOMContentLoaded', () => {
+			const themesFilterContainer = document.querySelector('.wp-filter .filter-links');
+			const bluehostPremiumThemesLink = document.createElement('li');
+			
+			bluehostPremiumThemesLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace/themes\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
+			themesFilterContainer.appendChild(bluehostPremiumThemesLink);
+		});
+		</script>
 
-        <?php
-    }
+		<?php
+	}
 
-    /**
-     * Filters query arguments to only retrieve block themes (full-site-editing) from the WordPress.org Themes API.
-     * 
-     *  @since 2.8.0
+	/**
+	 * Filters query arguments to only retrieve block themes (full-site-editing) from the WordPress.org Themes API.
+	 * 
+	 *  @since 2.8.0
 	 *
 	 * @param object $args   Arguments used to query for installer pages from the WordPress.org Themes API.
 	 * @param string $action Requested action. Likely values are 'theme_information',
 	 *                       'feature_list', or 'query_themes'.
-     * 
-     * @return object updated $args for this request.
-     */
-    public static function query_block_themes_args( $args, $action ) {
+	 * 
+	 * @return object updated $args for this request.
+	 */
+	public static function query_block_themes_args( $args, $action ) {
 
-        if ( 'query_themes' === $action && 'popular' === $args->browse ) {
-            if ( isset( $args->page ) ) {
-                $page = $args->page;
-            }
+		if ( 'query_themes' === $action && 'popular' === $args->browse ) {
+			if ( isset( $args->page ) ) {
+				$page = $args->page;
+			}
 
-            $args = ( object ) [
-                'tag' => 'full-site-editing',
-                'per_page' => 30,
-                'page' => $page,
-                'browse' => 'popular'
-            ];
-        }
+			$args = ( object ) [
+				'tag' => 'full-site-editing',
+				'per_page' => 30,
+				'page' => $page,
+				'browse' => 'popular'
+			];
+		}
 
-        return $args;
-    }
+		return $args;
+	}
 
-    /**
-     * Sorts the returned WordPress.org Themes API response to show self::$priorityThemes on top.
+	/**
+	 * Sorts the returned WordPress.org Themes API response to show self::$priorityThemes on top.
 	 *
 	 * @since 2.8.0
 	 *
@@ -86,80 +86,80 @@ class Themes {
 	 * @param string                  $action Requested action. Likely values are 'theme_information',
 	 *                                        'feature_list', or 'query_themes'.
 	 * @param stdClass                $args   Arguments used to query for installer pages from the WordPress.org Themes API.
-     * 
-     * @return stdClass $res sorted themes with self::$priorityThemes on top.
-     */
-    public static function sort_query_themes_results( $res, $action, $args ) {
+	 * 
+	 * @return stdClass $res sorted themes with self::$priorityThemes on top.
+	 */
+	public static function sort_query_themes_results( $res, $action, $args ) {
 
-        if ( 'query_themes' === $action && 'popular' === $args->browse ) {
+		if ( 'query_themes' === $action && 'popular' === $args->browse ) {
 
-            $themesToShowFirst = [];
-            foreach ( $res->themes as $key => $theme ) {
-                if ( in_array( $theme->slug, self::$priorityThemes, true ) ) {
-                    $themesToShowFirst[] = $theme;
+			$themesToShowFirst = [];
+			foreach ( $res->themes as $key => $theme ) {
+				if ( in_array( $theme->slug, self::$priorityThemes, true ) ) {
+					$themesToShowFirst[] = $theme;
 
-                    unset( $res->themes[$key] );
-                }
-            }
-            $sortedThemesResults = array_merge( $res->themes, $themesToShowFirst );
+					unset( $res->themes[$key] );
+				}
+			}
+			$sortedThemesResults = array_merge( $res->themes, $themesToShowFirst );
 
-            $sortedThemesResults = array_merge( $themesToShowFirst, $res->themes );
-            $res->themes = $sortedThemesResults;
-        }
+			$sortedThemesResults = array_merge( $themesToShowFirst, $res->themes );
+			$res->themes = $sortedThemesResults;
+		}
 
-        return $res;
-    }
+		return $res;
+	}
 
-    /**
-     * Renders "Recommended" ribbon on the Yith Wonder theme card.
-     */
-    public static function recommended_theme_ribbon() {
-        ?>
+	/**
+	 * Renders "Recommended" ribbon on the Yith Wonder theme card.
+	 */
+	public static function recommended_theme_ribbon() {
+		?>
 
-        <style>
-            .bluehost-recommended-theme {
-                box-shadow: 0 0 0 3px #a4acb9;
-            }
+		<style>
+			.bluehost-recommended-theme {
+				box-shadow: 0 0 0 3px #a4acb9;
+			}
 
-            .bluehost-recommended-theme::after {
-                content: "Recommended";
-                position: absolute;
-                top: -15px;
-                right: 5%;
-                background-color: #355ed3;
-                color: white;
-                padding: 5px 10px;
-                border-radius: 1.5px;
-            }
-        </style>
+			.bluehost-recommended-theme::after {
+				content: "Recommended";
+				position: absolute;
+				top: -15px;
+				right: 5%;
+				background-color: #355ed3;
+				color: white;
+				padding: 5px 10px;
+				border-radius: 1.5px;
+			}
+		</style>
 
-        <script type="text/javascript">
-            window.addEventListener('DOMContentLoaded', () => {
+		<script type="text/javascript">
+			window.addEventListener('DOMContentLoaded', () => {
 
-                const priorityThemeslug = 'yith-wonder';
-                const themesContainer = document.querySelector('.theme-browser');
+				const priorityThemeslug = 'yith-wonder';
+				const themesContainer = document.querySelector('.theme-browser');
 
-                const themesLoaded = (mutationList, observer) => {
-                    for (const mutation of mutationList) {
-                        if (mutation.type === 'childList') {
-                            const themes = document.querySelector('.theme-browser .themes');
-                            const yithTheme = themesContainer.querySelector('.theme[data-slug="' + priorityThemeslug + '"]');
-                            if (yithTheme) {
-                                yithTheme.classList.add('bluehost-recommended-theme');
-                            }
-                        }
-                    }
-                }
+				const themesLoaded = (mutationList, observer) => {
+					for (const mutation of mutationList) {
+						if (mutation.type === 'childList') {
+							const themes = document.querySelector('.theme-browser .themes');
+							const yithTheme = themesContainer.querySelector('.theme[data-slug="' + priorityThemeslug + '"]');
+							if (yithTheme) {
+								yithTheme.classList.add('bluehost-recommended-theme');
+							}
+						}
+					}
+				}
 
-                const observer = new MutationObserver(themesLoaded);
-                observer.observe(themesContainer, {
-                    childList: true,
-                    subtree: true
-                });
+				const observer = new MutationObserver(themesLoaded);
+				observer.observe(themesContainer, {
+					childList: true,
+					subtree: true
+				});
 
-            });
-        </script>
+			});
+		</script>
 
-        <?php
-    }
+		<?php
+	}
 }

--- a/inc/menu.php
+++ b/inc/menu.php
@@ -37,25 +37,6 @@ function bluehost_add_tool_bar_items( WP_Admin_Bar $admin_bar ) {
 add_action( 'admin_bar_menu', 'bluehost_add_tool_bar_items', 100 );
 
 /**
- * Add Marketplace premium themes link to WP themes.
- */
-function bluehost_add_theme_premium_link() {
-	?>
-	<script type="text/javascript">
-	window.addEventListener('DOMContentLoaded', () => {
-		const themesFilterContainer = document.querySelector('.wp-filter .filter-links');
-		const bluehostPremiumThemesLink = document.createElement('li');
-		
-		bluehostPremiumThemesLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace/themes\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
-		themesFilterContainer.appendChild(bluehostPremiumThemesLink);
-	});
-	</script>
-	<?php
-}
-
-add_action( 'admin_head-theme-install.php', 'bluehost_add_theme_premium_link' );
-
-/**
  * Add Marketplace premium plugins link to WP plugins.
  */
 function bluehost_add_plugin_premium_link() {

--- a/inc/menu.php
+++ b/inc/menu.php
@@ -45,7 +45,7 @@ function bluehost_add_plugin_premium_link() {
 	window.addEventListener('DOMContentLoaded', () => {
 		const pluginsFilterContainer = document.querySelector('.wp-filter .filter-links');
 		const bluehostPremiumPluginsLink = document.createElement('li');
-		
+
 		bluehostPremiumPluginsLink.innerHTML = '<a style="text-decoration: none;" onclick="location.href=\'admin.php?page=bluehost#/marketplace\'"><?php esc_html_e( 'Premium', 'bluehost-wordpress-plugin' ); ?></a>';
 		pluginsFilterContainer.appendChild(bluehostPremiumPluginsLink);
 	});


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

* Only retrieve FSE themes when a user is browsing themes under the popular tab.

* Show recommended themes first in the WP themes browser.

* Moved themes.php related code from menu.php as it fits better here.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
