### PR TITLE
update wpscholar collection reference to wp_forge collection

### DIFF
--- a/inc/Notifications/NotificationsRepository.php
+++ b/inc/Notifications/NotificationsRepository.php
@@ -4,7 +4,7 @@ namespace Bluehost\Notifications;
 
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
 use WP_Forge\Helpers\Arr;
-use wpscholar\Collection;
+use WP_Forge\Collection\Collection;
 
 /**
  * Class NotificationsRepository


### PR DESCRIPTION
## Proposed changes

There was a reference to wpscholar\Collection but it was no longer included in packages, so it was causing a fatal. This points it to the already included WP_Forge equivalent.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
