### PR TITLE
Add/marketplace links

### DIFF
--- a/inc/admin/class-page.php
+++ b/inc/admin/class-page.php
@@ -40,19 +40,19 @@ class Bluehost_Admin_App_Page {
 			),
 			array(
 				'slug'  => 'marketplace-featured',
-				'path'  => '/marketplace/featured',
+				'path'  => '/marketplace/featured&from=marketplace-nav-link',
 				'label' => __( ' - Featured', 'bluehost-wordpress-plugin' ),
 				'inapp' => false,
 			),
 			array(
 				'slug'  => 'marketplace-themes',
-				'path'  => '/marketplace/themes',
+				'path'  => '/marketplace/themes&from=marketplace-nav-link',
 				'label' => __( ' - Themes', 'bluehost-wordpress-plugin' ),
 				'inapp' => false,
 			),
 			array(
 				'slug'  => 'marketplace-seo',
-				'path'  => '/marketplace/seo',
+				'path'  => '/marketplace/seo&from=marketplace-nav-link',
 				'label' => __( ' - SEO', 'bluehost-wordpress-plugin' ),
 				'inapp' => false,
 			),

--- a/inc/admin/class-page.php
+++ b/inc/admin/class-page.php
@@ -30,51 +30,49 @@ class Bluehost_Admin_App_Page {
 				'slug'  => 'home',
 				'path'  => '/home',
 				'label' => __( 'Home', 'bluehost-wordpress-plugin' ),
+				'inapp' => true,
 			),
 			array(
 				'slug'  => 'marketplace',
 				'path'  => '/marketplace',
 				'label' => __( 'Marketplace', 'bluehost-wordpress-plugin' ),
+				'inapp' => true,
+			),
+			array(
+				'slug'  => 'marketplace-featured',
+				'path'  => '/marketplace/featured',
+				'label' => __( ' - Featured', 'bluehost-wordpress-plugin' ),
+				'inapp' => false,
+			),
+			array(
+				'slug'  => 'marketplace-themes',
+				'path'  => '/marketplace/themes',
+				'label' => __( ' - Themes', 'bluehost-wordpress-plugin' ),
+				'inapp' => false,
+			),
+			array(
+				'slug'  => 'marketplace-seo',
+				'path'  => '/marketplace/seo',
+				'label' => __( ' - SEO', 'bluehost-wordpress-plugin' ),
+				'inapp' => false,
 			),
 			array(
 				'slug'  => 'staging',
 				'path'  => '/tools/staging',
 				'label' => __( 'Staging', 'bluehost-wordpress-plugin' ),
+				'inapp' => true,
 			),
 			array(
 				'slug'  => 'settings',
 				'path'  => '/settings',
 				'label' => __( 'Settings', 'bluehost-wordpress-plugin' ),
+				'inapp' => true,
 			),
 			array(
 				'slug'  => 'help',
 				'path'  => '/help',
 				'label' => __( 'Help', 'bluehost-wordpress-plugin' ),
-			),
-		);
-	}
-	
-	/**
-	 * Get Marketplace sublevel pages.
-	 *
-	 * @return array[]
-	 */
-	public static function get_marketplace_subpages() {
-		return array(
-			array(
-				'slug'  => 'marketplace-featured',
-				'path'  => '/marketplace/featured',
-				'label' => __( '- Featured', 'bluehost-wordpress-plugin' ),
-			),
-			array(
-				'slug'  => 'marketplace-themes',
-				'path'  => '/marketplace/themes',
-				'label' => __( '- Themes', 'bluehost-wordpress-plugin' ),
-			),
-			array(
-				'slug'  => 'marketplace-seo',
-				'path'  => '/marketplace/seo',
-				'label' => __( '- SEO', 'bluehost-wordpress-plugin' ),
+				'inapp' => true,
 			),
 		);
 	}
@@ -151,19 +149,6 @@ class Bluehost_Admin_App_Page {
 				'bluehost#' . $data['path'],
 				array( $this, 'handle_subpage_redirect' )
 			);
-			// Add Marketplace subpages
-			if ( 'Marketplace' === $data['label'] ) {
-				foreach ( self::get_marketplace_subpages() as $subdata ) {
-					add_submenu_page(
-						'bluehost',
-						$subdata['label'],
-						$subdata['label'],
-						'manage_options',
-						'bluehost#' . $subdata['path'],
-						array( $this, 'handle_subpage_redirect' )
-					);
-				}
-			}
 		}
 	}
 

--- a/inc/admin/class-page.php
+++ b/inc/admin/class-page.php
@@ -53,6 +53,31 @@ class Bluehost_Admin_App_Page {
 			),
 		);
 	}
+	
+	/**
+	 * Get Marketplace sublevel pages.
+	 *
+	 * @return array[]
+	 */
+	public static function get_marketplace_subpages() {
+		return array(
+			array(
+				'slug'  => 'marketplace-featured',
+				'path'  => '/marketplace/featured',
+				'label' => __( '- Featured', 'bluehost-wordpress-plugin' ),
+			),
+			array(
+				'slug'  => 'marketplace-themes',
+				'path'  => '/marketplace/themes',
+				'label' => __( '- Themes', 'bluehost-wordpress-plugin' ),
+			),
+			array(
+				'slug'  => 'marketplace-seo',
+				'path'  => '/marketplace/seo',
+				'label' => __( '- SEO', 'bluehost-wordpress-plugin' ),
+			),
+		);
+	}
 
 	/**
 	 * Return instance
@@ -126,6 +151,19 @@ class Bluehost_Admin_App_Page {
 				'bluehost#' . $data['path'],
 				array( $this, 'handle_subpage_redirect' )
 			);
+			// Add Marketplace subpages
+			if ( 'Marketplace' === $data['label'] ) {
+				foreach ( self::get_marketplace_subpages() as $subdata ) {
+					add_submenu_page(
+						'bluehost',
+						$subdata['label'],
+						$subdata['label'],
+						'manage_options',
+						'bluehost#' . $subdata['path'],
+						array( $this, 'handle_subpage_redirect' )
+					);
+				}
+			}
 		}
 	}
 

--- a/src/app/components/organisms/bwa-common-header/desktop-tabs/index.js
+++ b/src/app/components/organisms/bwa-common-header/desktop-tabs/index.js
@@ -27,7 +27,12 @@ const DesktopTabs = () => {
 	return (
 		<nav className="bwa-desktop-nav__inner">
 			<ul className="bwa-desktop-nav__items">
-				{ topLevelPages.map( ( item ) => <DesktopTab item={ item } key={ item.slug } /> ) }
+				{ topLevelPages.map(
+					( item ) => (
+						item.inapp ?
+							<DesktopTab item={ item } key={ item.slug } /> : ''
+					)
+				)}
 			</ul>
 		</nav>
 	);

--- a/src/app/components/organisms/bwa-common-header/mobile-sidebar/index.js
+++ b/src/app/components/organisms/bwa-common-header/mobile-sidebar/index.js
@@ -25,10 +25,12 @@ const PrimaryMenu = () => {
 	});
 	return (
 		<ul className="main">
-			{ topLevelPages.map((item) => (
+			{ topLevelPages.map(
+				(item) => (
+					item.inapp ? 
 					<li className={ ['tab ' + item.slug] } key={ item.slug }>
 						<NavLink to={ item.path } activeClassName="is-active">{ item.label }</NavLink>
-					</li>
+					</li> : ''
 				)
 			) }
 		</ul>

--- a/src/app/functions/highlightTopLevel.js
+++ b/src/app/functions/highlightTopLevel.js
@@ -24,6 +24,15 @@ export const handleWPMenuActiveHighlight = ( topLevelSlug ) => {
             liToActivate.classList.add( 'current' );
             bluehostWpSubMenuNode.style = 'display: block;';
         }
+        // handle marketplace deep linking from admin menu
+        if ( topLevelSlug.includes('marketplace-') ) {
+            // get marketplace button
+            const marketplaceCat = topLevelSlug.split('-');
+            const marketplaceButton = document.querySelector( '.components-tab-panel__tabs-item.newfold-marketplace-tab-'+marketplaceCat[1] );
+            if ( marketplaceButton.hasAttribute('aria-selected') && 'false' == marketplaceButton.getAttribute('aria-selected') ) { 
+                marketplaceButton.click();
+            }
+        }
     } catch ( e ) {
         // 
     }


### PR DESCRIPTION
## Proposed changes

This adds some marketplace category links (hard coded) to the plugin wpadmin menu links.

The plugin menu links also power the plugin app links, so adding a flag to omit them from the app menu building and app mobile menu building components and also adding some handling for when these links are clicked to trigger navigating the marketplace when it's already open.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
