### PR TITLE
Properly route customize site links when active theme is FSE

### DIFF
--- a/inc/RestApi/CustomizeSiteController.php
+++ b/inc/RestApi/CustomizeSiteController.php
@@ -8,7 +8,7 @@ namespace Bluehost\RestApi;
  * This class is responsible for redirecting the user to the correct destination when they click the "Customize Site" button.
  */
 class CustomizeSiteController extends \WP_REST_Controller {
-	
+
 	/**
 	 * The namespace of this controller's route.
 	 *
@@ -25,8 +25,8 @@ class CustomizeSiteController extends \WP_REST_Controller {
 			$this->namespace,
 			'/customize-site',
 			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'redirect_destination' ),
+				'methods'  => \WP_REST_Server::READABLE,
+				'callback' => array( $this, 'redirect_destination' ),
 			)
 		);
 

--- a/inc/RestApi/CustomizeSiteController.php
+++ b/inc/RestApi/CustomizeSiteController.php
@@ -4,11 +4,11 @@ namespace Bluehost\RestApi;
 
 /**
  * Class CustomizeSiteController
- * 
+ *
  * This class is responsible for redirecting the user to the correct destination when they click the "Customize Site" button.
  */
-class CustomizeSiteController extends \WP_REST_Controller
-{
+class CustomizeSiteController extends \WP_REST_Controller {
+	
 	/**
 	 * The namespace of this controller's route.
 	 *
@@ -19,30 +19,28 @@ class CustomizeSiteController extends \WP_REST_Controller
 	/**
 	 * Registers the customizer route
 	 */
-	public function register_routes()
-	{
+	public function register_routes() {
+
 		register_rest_route(
 			$this->namespace,
 			'/customize-site',
 			array(
-				'methods'             =>  \WP_REST_Server::READABLE,
+				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'redirect_destination' ),
 			)
 		);
+
 	}
 
 	/**
 	 * Redirects to the correct destination based on the active theme.
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 *
-	 * @return \WP_REST_Response
 	 */
 	public function redirect_destination() {
-		$is_fse = is_readable( STYLESHEETPATH . '/templates/index.html' );
+		$is_fse      = is_readable( STYLESHEETPATH . '/templates/index.html' );
 		$destination = get_admin_url() . ( $is_fse ? 'site-editor.php' : 'customize.php' );
-		
-		wp_redirect( $destination );
-  		exit;
+
+		wp_safe_redirect( $destination );
+		exit;
 	}
+
 }

--- a/inc/RestApi/CustomizeSiteController.php
+++ b/inc/RestApi/CustomizeSiteController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Bluehost\RestApi;
+
+/**
+ * Class CustomizeSiteController
+ * 
+ * This class is responsible for redirecting the user to the correct destination when they click the "Customize Site" button.
+ */
+class CustomizeSiteController extends \WP_REST_Controller
+{
+	/**
+	 * The namespace of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'bluehost/v1';
+
+	/**
+	 * Registers the customizer route
+	 */
+	public function register_routes()
+	{
+		register_rest_route(
+			$this->namespace,
+			'/customize-site',
+			array(
+				'methods'             =>  \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'redirect_destination' ),
+			)
+		);
+	}
+
+	/**
+	 * Redirects to the correct destination based on the active theme.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function redirect_destination() {
+		$is_fse = is_readable( STYLESHEETPATH . '/templates/index.html' );
+		$destination = get_admin_url() . ( $is_fse ? 'site-editor.php' : 'customize.php' );
+		
+		wp_redirect( $destination );
+  		exit;
+	}
+}

--- a/inc/RestApi/rest-api.php
+++ b/inc/RestApi/rest-api.php
@@ -9,6 +9,7 @@ function bluehost_init_rest_api() {
 		'Bluehost\\RestApi\\AdminErrorController',
 		'Bluehost\\RestApi\\BluehostBlogController',
 		'Bluehost\\RestApi\\CachingController',
+		'Bluehost\\RestApi\\CustomizeSiteController',
 		'Bluehost\\RestApi\\SettingsController',
 		'Bluehost\\RestApi\\StagingController',
 	);

--- a/src/app/pages/home/onboarding/steps/look-right/index.js
+++ b/src/app/pages/home/onboarding/steps/look-right/index.js
@@ -8,7 +8,7 @@ export const LookRightStep = () => {
         <BaseStep>
             <img className="illustration" src={designUrl} alt={__("Designer working on a website", 'bluehost-wordpress-plugin')} />
             <p>{__("You want your site to look just right - maybe you want it to match your company colors, to be serious or fun, simple or bold—whatever's you. Customize the look of your site, or", 'bluehost-wordpress-plugin')} <a href='#/home/onboarding/premium-themes'>{__('browse our premium themes', 'bluehost-wordpress-plugin')}</a> {__(" to find something that fits you just right.", 'bluehost-wordpress-plugin')}</p>
-            <BWAButton isPrimary href="customize.php">{__('Customize your site', 'bluehost-wordpress-plugin')}</BWAButton>
+            <BWAButton isPrimary href={window.nfdRestRoot + '/bluehost/v1/customize-site'}>{__('Customize your site', 'bluehost-wordpress-plugin')}</BWAButton>
         </BaseStep>
     );
 }

--- a/src/app/pages/home/sections.js
+++ b/src/app/pages/home/sections.js
@@ -207,7 +207,7 @@ export const DesignBuildSection = ( props ) => {
             title={ __( 'Customizer', 'bluehost-wordpress-plugin' ) }
             desc={ __( 'Make edits and see changes before you update.', 'bluehost-wordpress-plugin' ) }>
             <BWAButton
-                href={ baseUrl + 'customize.php' }
+                href={ window.nfdRestRoot + '/bluehost/v1/customize-site' }
                 isSecondary
             >
                 { __( 'Customize Theme', 'bluehost-wordpress-plugin' ) }

--- a/tests/cypress/integration/home.cy.js
+++ b/tests/cypress/integration/home.cy.js
@@ -101,7 +101,7 @@ describe('Home Page', () => {
 					cy.contains('a.bluehost.components-button', 'Customize Theme');
 					cy.get('a.bluehost.components-button')
 						.should('have.attr', 'href')
-						.and('include', '/wp-admin/customize.php');
+						.and('include', '/customize-site');
 				});
 
 		});

--- a/tests/cypress/integration/onboarding.cy.js
+++ b/tests/cypress/integration/onboarding.cy.js
@@ -94,8 +94,9 @@ describe('Onboarding', () => {
 
 		cy.get('.nf-onboarding-base-step .components-button')
 			.should('be.visible')
-			.and('have.attr', 'href', 'customize.php')
-			.and('have.text', 'Customize your site');
+			.and('have.text', 'Customize your site')
+			.and('have.attr', 'href')
+			.and('include', '/customize-site');
 	})
 
 	it('Launch Tab', () => {


### PR DESCRIPTION
## Proposed changes

Add a Rest endpoint to handle redirection to the correct editor/customizer destination based on the active theme.

![ezgif-1-24cdefeb0f](https://user-images.githubusercontent.com/38976631/223663327-f49f9e6b-1dea-418b-bf03-f814dc20c4bc.gif)

Addresses: #330 

If there's a better approach to this, please let me know.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
