### PR TITLE
Bump ecommerce on npm to 0.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "bluehost-wordpress-plugin",
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@newfold-labs/wp-module-ecommerce": "github:newfold-labs/wp-module-ecommerce#v0.8.2",
+                "@newfold-labs/wp-module-ecommerce": "github:newfold-labs/wp-module-ecommerce#v0.8.3",
                 "@wordpress/a11y": "^3.30.0",
                 "@wordpress/api-fetch": "^3.6.2",
                 "@wordpress/components": "^23.7.0",
@@ -3231,7 +3231,7 @@
         },
         "node_modules/@newfold-labs/wp-module-ecommerce": {
             "version": "0.8.0",
-            "resolved": "git+ssh://git@github.com/newfold-labs/wp-module-ecommerce.git#1d45e3b622d6fbcad2c7cb901774ce76126981d7",
+            "resolved": "git+ssh://git@github.com/newfold-labs/wp-module-ecommerce.git#63cd5f9cedba3f29bedf08bb73d07237fd2b8293",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@wordpress/api-fetch": "^3.6.2",
@@ -24527,8 +24527,8 @@
             }
         },
         "@newfold-labs/wp-module-ecommerce": {
-            "version": "git+ssh://git@github.com/newfold-labs/wp-module-ecommerce.git#1d45e3b622d6fbcad2c7cb901774ce76126981d7",
-            "from": "@newfold-labs/wp-module-ecommerce@github:newfold-labs/wp-module-ecommerce#v0.8.2",
+            "version": "git+ssh://git@github.com/newfold-labs/wp-module-ecommerce.git#63cd5f9cedba3f29bedf08bb73d07237fd2b8293",
+            "from": "@newfold-labs/wp-module-ecommerce@github:newfold-labs/wp-module-ecommerce#v0.8.3",
             "requires": {
                 "@wordpress/api-fetch": "^3.6.2",
                 "@wordpress/components": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "npm": ">=7"
     },
     "dependencies": {
-        "@newfold-labs/wp-module-ecommerce": "github:newfold-labs/wp-module-ecommerce#v0.8.2",
+        "@newfold-labs/wp-module-ecommerce": "github:newfold-labs/wp-module-ecommerce#v0.8.3",
         "@wordpress/a11y": "^3.30.0",
         "@wordpress/api-fetch": "^3.6.2",
         "@wordpress/components": "^23.7.0",


### PR DESCRIPTION
## Proposed changes
It seems only the PHP side of ecommerce module was updated. Need to update the relevant npm version as well

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
