### PR TITLE
Add NotificationFeed to display in-app messages

### DIFF
--- a/src/app/components/notifications/feed.js
+++ b/src/app/components/notifications/feed.js
@@ -1,0 +1,74 @@
+import { createContext, useContext, useReducer } from "@wordpress/element";
+import { Notifications } from "@yoast/ui-library";
+
+const actions = { PUSH: "push", DISMISS: "dismiss" };
+
+/**
+ * @typedef FeedEntry
+ * @property {string} title
+ * @property {React.ReactNode | string[]} description
+ * @property {"info" | "success" | "error" | "warning"} variant
+ * @property {"bottom-left" | "bottom-center" | "top-center"} position
+ */
+
+/**
+ *
+ * @typedef FeedReducerAction
+ * @property {"push" | "dismiss"} type
+ * @property {string} id
+ * @property {FeedEntry?} message
+ *
+ * @param {Record<string, FeedEntry>} feed
+ * @param {FeedReducerAction} action
+ * @returns {Record<string, FeedEntry>}
+ */
+function feedReducer(feed, action) {
+  switch (action.type) {
+    case actions.PUSH:
+      return { ...feed, [action.id]: action.message };
+    case actions.DISMISS:
+      return { ...feed, [action.id]: null };
+    default:
+      return feed;
+  }
+}
+
+const FeedContext = createContext({
+  push: (id, message) => {},
+});
+
+/** @type {() => { push: (id: string, message: FeedEntry) => void}}  */
+export const useNotification = () => useContext(FeedContext);
+
+export function NotificationFeed({ children }) {
+  let [feed, dispatch] = useReducer(feedReducer, {});
+  return (
+    <>
+      <FeedContext.Provider
+        value={{
+          push: (id, message) => dispatch({ type: actions.PUSH, id, message }),
+        }}
+      >
+        {children}
+      </FeedContext.Provider>
+      <Notifications>
+        {Object.entries(feed)
+          .filter(([, value]) => value !== null)
+          .map(([key, { description, ...entry }]) => {
+            let contentProps = Array.isArray(description)
+              ? { description }
+              : { children: description };
+            return (
+              <Notifications.Notification
+                id={key}
+                {...entry}
+                {...contentProps}
+                dismissScreenReaderLabel="Dismiss"
+                onDismiss={(id) => dispatch({ type: actions.DISMISS, id })}
+              />
+            );
+          })}
+      </Notifications>
+    </>
+  );
+}

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -24,6 +24,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { SideNav } from './components/side-nav';
 import { SiteInfoBar } from './components/site-info';
+import { NotificationFeed } from './components/notifications/feed';
 
 const Notices = () => {
 	if ( 'undefined' === typeof noticesStore ) {
@@ -112,12 +113,14 @@ const AppBody = ( props ) => {
 export const App = () => (
 	<AppStoreProvider>
 		<Root context={ { isRtl: false } }>
-			<Router>
-				<div className="wppb-app-container yst-p-4 min-[783px]:yst-p-8 yst-flex yst-gap-6 yst-max-w-full xl:yst-max-w-screen-xl 2xl:yst-max-w-screen-2xl yst-my-0 yst-mx-auto">
-					<SideNav />
-					<AppBody />
-				</div>
-			</Router>
+			<NotificationFeed>
+				<Router>
+					<div className="wppb-app-container yst-p-4 min-[783px]:yst-p-8 yst-flex yst-gap-6 yst-max-w-full xl:yst-max-w-screen-xl 2xl:yst-max-w-screen-2xl yst-my-0 yst-mx-auto">
+						<SideNav />
+						<AppBody />
+					</div>
+				</Router>
+			</NotificationFeed>
 		</Root>
 	</AppStoreProvider>
 );

--- a/src/app/pages/ecommerce/page.js
+++ b/src/app/pages/ecommerce/page.js
@@ -1,5 +1,6 @@
 import "@newfold-labs/wp-module-ecommerce";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useNotification } from "../../components/notifications/feed";
 import { Page } from "../../components/page";
 import "./styles.scss";
 
@@ -9,8 +10,9 @@ const ECommerce = () => {
     let params = useSearchParams();
     let location = useLocation();
     let navigate = useNavigate();
+    let notify = useNotification();
     let state = { wp: { comingSoon: false }, params, location: location.pathname };
-    let wpModules = { navigate };
+    let wpModules = { navigate, notify };
     let actions = { toggleComingSoon: () => Promise.resolve() };
     return (
         <Page>

--- a/src/app/tailwind.pcss
+++ b/src/app/tailwind.pcss
@@ -169,3 +169,13 @@
 		}
 	}
 }
+
+/* Notifications */
+@layer components {
+	.yst-root {
+
+        .yst-notifications--bottom-left {
+            @apply yst-left-[12%];
+        }
+	}
+}


### PR DESCRIPTION
### NotificationFeed

As we need to show messages during flows in the plugin, this PR introduces a NotificationFeed that is placed at the top of the app. The app now has a `useNotification` hook that can be used to push messages to the feed.

```jsx
let notify = useNotification();
notify.push("woo-failure", {
  title: "WooCommerce failed to install",
  description: (
    <span>
      {__("Please try again, or contact support", "wp-module-ecommerce")}
    </span>
  ),
  variant: "error",
});
```

You can check the [StoryBook](https://ui-library.yoast.com/?path=/docs/2-components-notifications--factory) to understand more about the components.

I had to also modify the base styling set by the Yoast library to make sure the notifications did not collide with the WP Sidenav.

### Out of the box styling 
<img width="385" alt="Screenshot 2023-05-19 at 3 50 47 PM" src="https://github.com/bluehost/bluehost-wordpress-plugin/assets/6629172/9f88a505-ddcc-498b-90da-be9827672f9a">

### Modifying with `tailwind.pcss`
<img width="384" alt="Screenshot 2023-05-19 at 4 06 08 PM" src="https://github.com/bluehost/bluehost-wordpress-plugin/assets/6629172/9833749c-793c-406d-9f00-e85bb79129f9">

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
