### PR TITLE
Pass comingSoon controls to ecommerce component

### DIFF
--- a/src/app/pages/ecommerce/page.js
+++ b/src/app/pages/ecommerce/page.js
@@ -1,28 +1,44 @@
-import "@newfold-labs/wp-module-ecommerce";
+import { NewfoldECommerce } from "@newfold-labs/wp-module-ecommerce";
+import { useContext } from "@wordpress/element";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useNotification } from "../../components/notifications/feed";
 import { Page } from "../../components/page";
+import AppStore from "../../data/store";
+import { blueprintSettingsApiFetch } from "../../util/helpers";
 import "./styles.scss";
 
-const NewfoldECommerce = window.NewfoldECommerce;
-
 const ECommerce = () => {
-    let params = useSearchParams();
-    let location = useLocation();
-    let navigate = useNavigate();
-    let notify = useNotification();
-    let state = { wp: { comingSoon: false }, params, location: location.pathname };
-    let wpModules = { navigate, notify };
-    let actions = { toggleComingSoon: () => Promise.resolve() };
-    return (
-        <Page>
-            <NewfoldECommerce
-                state={state}
-                wpModules={wpModules}
-                actions={actions}
-            />
-        </Page>
-    );
-}
+  const { store, setStore } = useContext(AppStore);
+  let params = useSearchParams();
+  let location = useLocation();
+  let navigate = useNavigate();
+  let notify = useNotification();
+  let state = {
+    wp: { comingSoon: store?.comingSoon },
+    params,
+    location: location.pathname,
+  };
+  let wpModules = { navigate, notify };
+
+  let actions = {
+    toggleComingSoon: () =>
+      blueprintSettingsApiFetch(
+        { comingSoon: !store.comingSoon },
+        console.error,
+        (response) => {
+          setStore({
+            ...store,
+            comingSoon: !store.comingSoon,
+          });
+        }
+      ),
+  };
+
+  return (
+    <Page>
+      <NewfoldECommerce state={state} wpModules={wpModules} actions={actions} />
+    </Page>
+  );
+};
 
 export default ECommerce;


### PR DESCRIPTION
## Proposed changes

Add `comingSoon` controls to the ecommerce component

cc @wpalani @wpscholar 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)