### PR TITLE
remove login form default redirect

### DIFF
--- a/inc/LoginRedirect.php
+++ b/inc/LoginRedirect.php
@@ -14,9 +14,7 @@ class LoginRedirect {
 	 */
 	public static function init() {
 		add_action( 'login_redirect', array( __CLASS__, 'on_login_redirect' ), 10, 3 );
-		add_action( 'login_init', array( __CLASS__, 'on_login_init' ), 10, 3 );
-        add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
-		add_filter( 'login_form_defaults', array( __CLASS__, 'filter_login_form_defaults' ) );
+		add_action( 'admin_init', array( __CLASS__, 'disable_yoast_onboarding_redirect' ), 2 );
 		add_filter( 'newfold_sso_success_url_default', array( __CLASS__, 'get_default_redirect_url' ) );
 	}
 
@@ -29,29 +27,6 @@ class LoginRedirect {
 	 */
 	public static function get_default_redirect_url( $url ) {
 		return current_user_can( 'manage_options' ) ? self::get_bluehost_dashboard_url() : $url;
-	}
-
-	/**
-	 * Set the $_REQUEST['redirect_to'] value on the login_init action since there isn't a better way to do it before
-	 * WordPress automatically defaults it to the WordPress dashboard URL.
-	 */
-	public static function on_login_init() {
-		if ( ! isset( $_REQUEST['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$_REQUEST['redirect_to'] = self::get_bluehost_dashboard_url();
-		}
-	}
-
-	/**
-	 * Set default redirect used in the wp_login_form() function.
-	 *
-	 * @param array $defaults Collection of existing defaults.
-	 *
-	 * @return array
-	 */
-	public static function filter_login_form_defaults( array $defaults ) {
-		$defaults['redirect'] = self::get_bluehost_dashboard_url();
-
-		return $defaults;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Should fix #512 

Let's not set the login form default redirect, since not all users can view the bluehost plugin screen we were redirecting to.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
