### PR TITLE
bluehost.com/about-us to bluehost.com/about

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -230,7 +230,7 @@ final class Admin {
 	 * @return string
 	 */
 	public static function add_brand_to_admin_footer( $footer_text ) {
-		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://bluehost.com/about-us">Bluehost</a>.', 'wp-plugin-bluehost' ) );
+		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://bluehost.com/about">Bluehost</a>.', 'wp-plugin-bluehost' ) );
 		return $footer_text;
 	}
 } // END \Bluehost\Admin

--- a/languages/wp-plugin-bluehost.pot
+++ b/languages/wp-plugin-bluehost.pot
@@ -122,7 +122,7 @@ msgid "Please update now"
 msgstr ""
 
 #: inc/Admin.php:187
-msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://bluehost.com/about-us\">Bluehost</a>."
+msgid "Thank you for creating with <a href=\"https://wordpress.org/\">WordPress</a> and <a href=\"https://bluehost.com/about\">Bluehost</a>."
 msgstr ""
 
 #: inc/AdminBar.php:35


### PR DESCRIPTION
## Proposed changes

Bluehost.com/about-us is now bluehost.com/about. That should receive a redirect, but we should link directly to the page now.

<img width="1449" alt="about-us-webstage-error" src="https://github.com/bluehost/bluehost-wordpress-plugin/assets/9565066/7620f250-fa83-4f54-b8f9-6c7da32ee5b8">


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
