### PR TITLE
Fix staging JSX errors

### DIFF
--- a/src/app/pages/staging/index.js
+++ b/src/app/pages/staging/index.js
@@ -23,8 +23,7 @@ const ProductionSite = ({
             title={__('Production site', 'wp-plugin-bluehost')}
             description={
                 <Radio
-                    defaultChecked={isProduction === true ? true : false}
-                    checked={isProduction === true ? true : false}
+                    checked={isProduction === true}
                     label={isProduction ? __('Currently editing', 'wp-plugin-bluehost') : __('Not currently editing', 'wp-plugin-bluehost') }
                     id="wppbh-production-toggle"
                     name="wppbh-staging-selector"
@@ -77,8 +76,7 @@ const StagingSite = ({
             title={__('Staging site', 'wp-plugin-bluehost')}
             description={!hasStaging ? __("You don't have a staging site yet.", 'wp-plugin-bluehost') :
                 <Radio
-                    defaultChecked={isProduction ? false : true}
-                    checked={isProduction ? false : true}
+                    checked={isProduction !== true}
                     label={isProduction ? __('Not currently editing', 'wp-plugin-bluehost') : __('Currently editing', 'wp-plugin-bluehost') }
                     id="wppbh-staging-toggle"
                     name="wppbh-staging-selector"


### PR DESCRIPTION
## Proposed changes

Fix console error due to having a RadioGroup.Radio element that has both the `defaultChecked` and `checked` attributes

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

