### PR TITLE
Enable 'Yoast AI' by default

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -204,6 +204,7 @@ require BLUEHOST_PLUGIN_DIR . '/inc/RestApi/SettingsController.php';
 require BLUEHOST_PLUGIN_DIR . '/inc/RestApi/rest-api.php';
 require BLUEHOST_PLUGIN_DIR . '/inc/settings.php';
 require BLUEHOST_PLUGIN_DIR . '/inc/updates.php';
+require BLUEHOST_PLUGIN_DIR . '/inc/YoastAI.php';
 
 /* WordPress Admin Page & Features */
 if ( is_admin() ) {

--- a/inc/YoastAI.php
+++ b/inc/YoastAI.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Bluehost;
+
+/**
+ * Class YoastAI
+ *
+ * @package Bluehost
+ */
+class YoastAI
+{
+    /*
+    * Initialize the Yoast AI class.
+    */
+    public static function init()
+    {
+        add_action( 'init', array( __CLASS__, 'on_yoast_plugin_activation' ) );
+        add_filter( 'http_request_args', array( __CLASS__,'modify_http_request_args' ), 10, 2 );
+    }
+
+    /*
+    * Register Yoast plugin activation hook to enable the Yoast AI generator on new activations.
+    */
+    public static function on_yoast_plugin_activation()
+    {
+        register_activation_hook( 'wordpress-seo/wp-seo.php', array( __CLASS__, 'enable_on_new_activations' ) );
+    }
+
+    /*
+    * Filter Yoast SEO default settings to enable AI on new installations/activations
+    */
+    public static function enable_on_new_activations()
+    {
+        add_filter(
+            'wpseo_option_wpseo_defaults',
+            function ( $defaults ) {
+                if ( ! is_array( $defaults ) || ! isset( $defaults['enable_ai_generator'] ) ) {
+                    return $defaults;
+                }
+                $defaults['enable_ai_generator'] = true;
+                return $defaults;
+            }
+        );
+    }
+
+    /*
+    * Add a custom header to outbound Yoast AI requests for Bluehost customers.
+    */
+    public static function modify_http_request_args( $parsed_args, $url )
+    {
+        $parsed_url = parse_url( $url );
+		if ( ! is_array( $parsed_url ) ) {
+			return $parsed_args;
+		}
+		if ( $parsed_url['host'] !== 'ai.yoa.st' ) {
+			return $parsed_args;
+		}
+		if ( is_array( $parsed_args['headers'] ) ) {
+			$parsed_args['headers']['X-Yst-Cohort'] = 'Bluehost';
+		}
+		return $parsed_args;
+    }
+}
+
+YoastAI::init();

--- a/inc/upgrades/3.1.1.php
+++ b/inc/upgrades/3.1.1.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Handle updates for version 3.1.1
+ *
+ * @package Bluehost
+ */
+
+// Enable Yoast AI on existing Yoast SEO installs
+if ( function_exists( 'yoastseo' ) ) {
+    // Only enable the enable_ai_generator setting if we have a stored value.
+	if ( yoastseo()->helpers->options->get( 'enable_ai_generator', null ) !== null ) {
+		yoastseo()->helpers->options->set( 'enable_ai_generator', true );
+	}
+}


### PR DESCRIPTION
## Proposed changes
This code enables Yoast AI functionality on new Yoast activations as well as existing ones.

I tested it by checking the `enable_ai_generator` value in the `wpseo` option, as well as by installing the premium plugin and verified the toggle for the feature was turned on.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
