### PR TITLE
Update distignore and distinclude rules

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,27 +4,35 @@
 /bin
 node_modules
 /src
-tests
+/tests
 
 # Files
-.*
+/.*
 cypress.config.js
 set-latest-wp-version.js
+webpack.config.js
 
 # File Types
-*.json
-*.lock
-*.log
-*.md
-*.sql
-*.tar.gz
-*.xml
-*.yml
-*.zip
-*.scss
+/*.json
+/*.lock
+/*.log
+/*.md
+/*.sql
+/*.tar.gz
+/*.xml
+/*.yml
+/*.zip
+/*.scss
 
-# Newfold src files
-vendor/newfold-labs/wp-module-ecommerce/src
-vendor/newfold-labs/wp-module-help-center/src
-vendor/newfold-labs/wp-module-onboarding/src
-vendor/newfold-labs/wp-module-patterns/src
+# BEGIN NEWFOLD LABS RULES
+vendor/newfold-labs/*/src
+vendor/newfold-labs/*/source
+vendor/newfold-labs/*/tests
+vendor/newfold-labs/*/.*
+vendor/newfold-labs/*/*.xml
+vendor/newfold-labs/*/*.json
+vendor/newfold-labs/*/*.lock
+vendor/newfold-labs/*/*.scss
+vendor/newfold-labs/*/*.md
+vendor/newfold-labs/*/*.config.js
+vendor/newfold-labs/*/LICENSE

--- a/.distinclude
+++ b/.distinclude
@@ -1,8 +1,6 @@
 # Directories
 
 # Files
-/vendor/newfold-labs/wp-module-data/src/Data/Static/*.json
-/vendor/newfold-labs/wp-module-patterns/build/*/blocks/block.json
-/vendor/newfold-labs/wp-module-staging/lib/.staging
+/LICENSE.md
 
 # File Types

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "newfold-labs/wp-module-coming-soon": "^1.1.9",
     "newfold-labs/wp-module-ctb": "^1.1.2",
     "newfold-labs/wp-module-customer-bluehost": "^1.6.0",
-    "newfold-labs/wp-module-data": "^2.4.6",
+    "newfold-labs/wp-module-data": "^2.4.7",
     "newfold-labs/wp-module-ecommerce": "^1.2.4",
     "newfold-labs/wp-module-global-ctb": "^1.0.4",
     "newfold-labs/wp-module-help-center": "1.0.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ad36b4561bfdf2856ed39a4e31dfd2f",
+    "content-hash": "508bad3ce9269d4d4ece2fb6fa64e98b",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/composer.lock
+++ b/composer.lock
@@ -418,16 +418,16 @@
         },
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.4.6",
+            "version": "2.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "03bc7b42c7957ee983944721f8251d772985abee"
+                "reference": "c8b20f346302221c3ac18125a651fce66ebe2516"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/03bc7b42c7957ee983944721f8251d772985abee",
-                "reference": "03bc7b42c7957ee983944721f8251d772985abee",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/c8b20f346302221c3ac18125a651fce66ebe2516",
+                "reference": "c8b20f346302221c3ac18125a651fce66ebe2516",
                 "shasum": ""
             },
             "require": {
@@ -441,7 +441,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "NewfoldLabs\\WP\\Module\\Data\\": "src/"
+                    "NewfoldLabs\\WP\\Module\\Data\\": "includes/"
                 },
                 "files": [
                     "bootstrap.php"
@@ -460,10 +460,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.6",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.4.7",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2023-09-22T19:59:31+00:00"
+            "time": "2023-09-28T17:34:55+00:00"
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",


### PR DESCRIPTION
Update distignore and distinclude rules to match other plugins.

Also includes compatibility update to the data module (moving PHP files from `/src` to `/includes` directory so it will not be ignored
 - Upgrading newfold-labs/wp-module-data (2.4.6 => 2.4.7)

This also coincides with the how we work update here: https://github.com/newfold-labs/how-we-work/pull/22


## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
