### PR TITLE
Fix for Newfold Runtime Updates

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -151,7 +151,7 @@ final class Admin {
 			\wp_register_script(
 				'bluehost-script',
 				BLUEHOST_BUILD_URL . '/index.js',
-				array_merge( $asset['dependencies'] ),
+				array_merge( $asset['dependencies'], [ 'nfd-runtime' ] ),
 				$asset['version'],
 				true
 			);

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -27,8 +27,8 @@ final class Admin {
 		/* Add inline style to hide subnav link */
 		\add_action( 'admin_head', array( __CLASS__, 'admin_nav_style' ) );
 
-		\add_filter('newfold-runtime', array( __CLASS__, 'add_to_runtime' ) );
-		\add_filter('newfold_runtime', array( __CLASS__, 'add_to_runtime' ) );
+		\add_filter( 'newfold-runtime', array( __CLASS__, 'add_to_runtime' ) );
+		\add_filter( 'newfold_runtime', array( __CLASS__, 'add_to_runtime' ) );
 
 		if ( isset( $_GET['page'] ) && strpos( filter_input( INPUT_GET, 'page', FILTER_UNSAFE_RAW ), 'bluehost' ) >= 0 ) { // phpcs:ignore
 			\add_action( 'admin_footer_text', array( __CLASS__, 'add_brand_to_admin_footer' ) );
@@ -37,6 +37,7 @@ final class Admin {
 
 	public static function add_to_runtime( $sdk ) {
 		include_once BLUEHOST_PLUGIN_DIR . '/inc/Data.php';
+
 		return array_merge( $sdk, Data::runtime() );
 	}
 
@@ -211,7 +212,8 @@ final class Admin {
 	/**
 	 * Add Links to WordPress Plugins list item for Bluehost.
 	 *
-	 * @param  array $actions - array of action links for Plugin row item.
+	 * @param array $actions - array of action links for Plugin row item.
+	 *
 	 * @return array
 	 */
 	public static function actions( $actions ) {
@@ -228,10 +230,12 @@ final class Admin {
 	 * Filter WordPress Admin Footer Text "Thank you for creating with..."
 	 *
 	 * @param string $footer_text footer text
+	 *
 	 * @return string
 	 */
 	public static function add_brand_to_admin_footer( $footer_text ) {
 		$footer_text = \sprintf( \__( 'Thank you for creating with <a href="https://wordpress.org/">WordPress</a> and <a href="https://bluehost.com/about">Bluehost</a>.', 'wp-plugin-bluehost' ) );
+
 		return $footer_text;
 	}
 } // END \Bluehost\Admin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "bluehost-wordpress-plugin",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "3.3.1",
+            "version": "3.3.2",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@heroicons/react": "^2.0.18",


### PR DESCRIPTION
## Proposed changes

Due to recent changes in the currently untagged Newfold Runtime (see https://github.com/newfold-labs/wp-module-runtime/pull/14), it is now necessary to explicitly add `nfd-runtime` as a script dependency to the Bluehost plugin's main script file. The change on the runtime module allows the Newfold runtime to be loaded in scenarios where the main Bluehost script file is not.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation Update (if none of the other choices apply)
