### PR TITLE
add deactivation module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "newfold-labs/wp-module-ctb": "^1.1.2",
     "newfold-labs/wp-module-customer-bluehost": "^1.6.0",
     "newfold-labs/wp-module-data": "^2.4.8",
+    "newfold-labs/wp-module-deactivation": "^1.0",
     "newfold-labs/wp-module-ecommerce": "^1.2.4",
     "newfold-labs/wp-module-global-ctb": "^1.0.4",
     "newfold-labs/wp-module-help-center": "1.0.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "218ccb837c139911e8bcd796c9a00e5f",
+    "content-hash": "f33ae9406e76a602c9b0c476871d3167",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -464,6 +464,67 @@
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
             "time": "2023-10-04T14:06:48+00:00"
+        },
+        {
+            "name": "newfold-labs/wp-module-deactivation",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/newfold-labs/wp-module-deactivation.git",
+                "reference": "66d9e4d888426094ee6eb3b66d03404a6e8110e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-deactivation/zipball/66d9e4d888426094ee6eb3b66d03404a6e8110e3",
+                "reference": "66d9e4d888426094ee6eb3b66d03404a6e8110e3",
+                "shasum": ""
+            },
+            "require": {
+                "newfold-labs/wp-module-data": "^2.0.0"
+            },
+            "require-dev": {
+                "newfold-labs/wp-php-standards": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NewfoldLabs\\WP\\Module\\Deactivation\\": "includes"
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "scripts": {
+                "fix": [
+                    "vendor/bin/phpcbf --standard=phpcs.xml ."
+                ],
+                "lint": [
+                    "vendor/bin/phpcs --standard=phpcs.xml -s ."
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Micah Wood",
+                    "email": "micah@wpscholar.com"
+                },
+                {
+                    "name": "Evan Mullins",
+                    "email": "evanrm@gmail.com"
+                },
+                {
+                    "name": "Al Ani",
+                    "email": "hey@alani.dev"
+                }
+            ],
+            "description": "A Module for handling WordPress brand plugins and modules deactivations",
+            "support": {
+                "source": "https://github.com/newfold-labs/wp-module-deactivation/tree/1.0.0",
+                "issues": "https://github.com/newfold-labs/wp-module-deactivation/issues"
+            },
+            "time": "2023-10-10T18:09:35+00:00"
         },
         {
             "name": "newfold-labs/wp-module-ecommerce",


### PR DESCRIPTION
## Proposed changes

This adds the deactivation module as well as automated cypress tests to ensure that it functions properly. The deactivate link for this plugin now opens a modal and requests user feedback on why they are deactivating the plugin. The modal can be canceled, skipped, and submitted with a user-generated reason (which is submitted as event data), all of which have tests in place.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
