### PR TITLE
Bump Onboarding to 1.11.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "newfold-labs/wp-module-loader": "^1.0.10",
     "newfold-labs/wp-module-marketplace": "^2.0.2",
     "newfold-labs/wp-module-notifications": "^1.1.6",
-    "newfold-labs/wp-module-onboarding": "^1.11.7",
+    "newfold-labs/wp-module-onboarding": "^1.11.8",
     "newfold-labs/wp-module-patterns": "^0.1.8",
     "newfold-labs/wp-module-performance": "^1.2.2",
     "newfold-labs/wp-module-runtime": "^1.0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8235d201e4471c586df8bd8eefe598a",
+    "content-hash": "2353e8f6bd164be4fe9d5910a97d5c87",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -873,16 +873,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "1.11.7",
+            "version": "1.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "c118868056d24635add01747a7562b94fd716773"
+                "reference": "196e62b8d741e825b11b52648cb23cd505597ca7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/c118868056d24635add01747a7562b94fd716773",
-                "reference": "c118868056d24635add01747a7562b94fd716773",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/196e62b8d741e825b11b52648cb23cd505597ca7",
+                "reference": "196e62b8d741e825b11b52648cb23cd505597ca7",
                 "shasum": ""
             },
             "require": {
@@ -925,10 +925,10 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.11.7",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/1.11.8",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2023-11-03T12:19:53+00:00"
+            "time": "2023-11-07T11:23:21+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",
@@ -3533,5 +3533,5 @@
     "platform-overrides": {
         "php": "7.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
This fixes Onboarding for WordPress 6.4 while ensuring backward compatibility with 6.3.
Release Notes: https://github.com/newfold-labs/wp-module-onboarding/releases/tag/1.11.8

Before: Onboarding Live Previews error.

https://github.com/bluehost/bluehost-wordpress-plugin/assets/38878906/55976a73-4fd3-4423-9d33-cf34a9b876c4

After: Onboarding Live Previews work as expected.

https://github.com/bluehost/bluehost-wordpress-plugin/assets/38878906/6a2c8836-590c-4049-aad5-4fdd80e7fd19

