### PR TITLE
update matrix workflow to only record if PR has a `debug` label added

### DIFF
--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -118,7 +118,7 @@ jobs:
         if: ${{ github.repository != 'bluehost/bluehost-wordpress-plugin' || github.actor == 'dependabot[bot]' || github.event.label.name != 'debug' }}
         run: npm run test:e2e -- --browser chrome
 
-      - name: Run Cypress Tests
+      - name: Run Cypress Cloud Tests
         if: ${{ github.repository == 'bluehost/bluehost-wordpress-plugin' && github.actor != 'dependabot[bot]' && github.event.label.name == 'debug' }}
         run: npm run test:e2e -- --browser chrome --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --tag "bluehost,php-${{ matrix.phpVersion }},wp-${{ matrix.wpVersion }}"
 

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -115,11 +115,11 @@ jobs:
         run: npx wp-env start --debug
 
       - name: Run Cypress Tests
-        if: ${{ github.repository != 'bluehost/bluehost-wordpress-plugin' || github.actor == 'dependabot[bot]' }}
+        if: ${{ github.repository != 'bluehost/bluehost-wordpress-plugin' || github.actor == 'dependabot[bot]' || github.event.label.name != 'debug' }}
         run: npm run test:e2e -- --browser chrome
 
       - name: Run Cypress Tests
-        if: ${{ github.repository == 'bluehost/bluehost-wordpress-plugin' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.repository == 'bluehost/bluehost-wordpress-plugin' && github.actor != 'dependabot[bot]' && github.event.label.name == 'debug' }}
         run: npm run test:e2e -- --browser chrome --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --tag "bluehost,php-${{ matrix.phpVersion }},wp-${{ matrix.wpVersion }}"
 
       - name: Store screenshots of test failures

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -2,7 +2,7 @@ name: Cypress Test Matrix
 
 on:
   pull_request:
-    types: [ opened, edited, reopened, ready_for_review, synchronize ]
+    types: [ opened, edited, reopened, ready_for_review, synchronize, labeled ]
     branches:
       - main
       - master

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install WordPress
         run: npx wp-env start --debug
 
-      - name: Run Cypress Tests
+      - name: Run Cypress Cloud Tests
         if: ${{ github.repository != 'bluehost/bluehost-wordpress-plugin' || github.actor == 'dependabot[bot]' }}
         run: npm run test:e2e -- --browser chrome
 


### PR DESCRIPTION
## Proposed changes

This will update our matrix tests to only record to cypress cloud if we have added a `debug` label to the PR. Happy to update it to anything else, but that felt simple enough without making a specific label for this one thing.

This should cut down a lot of our cloud usage (and charges) and still give us a simple way to trigger the matrix recording in cloud as needed.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
