### PR TITLE
Press4-444 Update Coming Soon Toggle to match Figma Designs 

### DIFF
--- a/src/app/pages/settings/comingSoon.js
+++ b/src/app/pages/settings/comingSoon.js
@@ -67,11 +67,11 @@ const ComingSoon = () => {
 		const getStatus = () => {
 			return comingSoon ? (
 				<span className="nfd-text-[#e10001]">
-					{ __( 'Coming Soon', 'wp-plugin-bluehost' ) }
+					{ __( 'NOT LIVE', 'wp-plugin-bluehost' ) }
 				</span>
 			) : (
 				<span className="nfd-text-[#008112]">
-					{ __( 'Live', 'wp-plugin-bluehost' ) }
+					{ __( 'LIVE', 'wp-plugin-bluehost' ) }
 				</span>
 			);
 		};
@@ -87,16 +87,17 @@ const ComingSoon = () => {
 		<Container.SettingsField
 			title={ getComingSoonSectionTitle() }
 			description={ __(
-				'Still building your site? Need to make a big change?',
+				comingSoon ? 'Turn off \'Maintenance Mode\' when you are ready to launch your website.'
+				: 'Turn on \"Maintenance Mode\" when you need to make major changes to your website.',
 				'wp-plugin-bluehost'
 			) }
 		>
 			<div className="nfd-flex nfd-flex-col nfd-gap-6">
 				<ToggleField
 					id="coming-soon-toggle"
-					label="Coming soon page"
+					label="Maintenance Mode"
 					description={ __(
-						'Your Bluehost Coming Soon page lets you hide your site from visitors while you make the magic happen.',
+						'When this is enabled, a placeholder page will be displayed to your website visitors to show that your site is still under construction or undergoing significant changes.',
 						'wp-plugin-bluehost'
 					) }
 					checked={ comingSoon }

--- a/src/app/pages/settings/comingSoon.js
+++ b/src/app/pages/settings/comingSoon.js
@@ -87,15 +87,15 @@ const ComingSoon = () => {
 		<Container.SettingsField
 			title={ getComingSoonSectionTitle() }
 			description={ __(
-				comingSoon ? 'Turn off \'Maintenance Mode\' when you are ready to launch your website.'
-				: 'Turn on \"Maintenance Mode\" when you need to make major changes to your website.',
+				comingSoon ? 'Turn off your "Coming Soon" page when you are ready to launch your website.'
+				: 'Turn on your "Coming Soon" page when you need to make major changes to your website.',
 				'wp-plugin-bluehost'
 			) }
 		>
 			<div className="nfd-flex nfd-flex-col nfd-gap-6">
 				<ToggleField
 					id="coming-soon-toggle"
-					label="Maintenance Mode"
+					label="Coming Soon page"
 					description={ __(
 						'When this is enabled, a placeholder page will be displayed to your website visitors to show that your site is still under construction or undergoing significant changes.',
 						'wp-plugin-bluehost'


### PR DESCRIPTION

Updated the "Site Status" setting UI to match the Figma.

![image](https://github.com/bluehost/bluehost-wordpress-plugin/assets/149479917/01f24d10-751a-4c12-81cb-d704d8963869)

![image](https://github.com/bluehost/bluehost-wordpress-plugin/assets/149479917/8a939672-58b9-42bb-80a6-76ee8973d4f8)
