### PR TITLE
Add `experimentalRunAllSpecs` to run all Cypress tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -71,6 +71,7 @@ module.exports = defineConfig( {
 		excludeSpecPattern: [
 			'vendor/newfold-labs/**/tests/cypress/integration/wp-module-support/*.cy.js', // skip any module's wp-module-support files
 		],
+		experimentalRunAllSpecs: true,
 	},
 	retries: 1,
 	experimentalMemoryManagement: true,


### PR DESCRIPTION
## Proposed changes

Previously, Cypress [removed the button to run all tests](https://github.com/cypress-io/cypress/discussions/21628?ref=cypress-io.ghost.io) but have added it back under an experimental config setting, `experimentalRunAllSpecs`.

https://www.cypress.io/blog/2023/01/12/check-out-our-experimental-release-of-run-all-specs

This PR adds `experimentalRunAllSpecs: true` in `cypress.config.js`, adding:

<img width="532" alt="Screenshot 2024-01-31 at 2 50 54 PM" src="https://github.com/bluehost/bluehost-wordpress-plugin/assets/4720401/a24fb5bc-f728-43ad-a1e3-64494afe40f8">


## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Linting and tests pass locally with my changes

## Further comments

