### PR TITLE
Fix: (one of) fatal error "No entry was found for 'comingSoon'"

### DIFF
--- a/inc/RestApi/SettingsController.php
+++ b/inc/RestApi/SettingsController.php
@@ -175,7 +175,7 @@ class SettingsController extends \WP_REST_Controller {
 		}
 
 		$settings = array(
-			'comingSoon'              => container()->get( 'comingSoon' )->is_enabled(),
+			'comingSoon'              => container()->has( 'comingSoon' ),
 			'autoUpdatesAll'          => $major && $plugins && $themes,
 			'autoUpdatesMajorCore'    => $major,
 			'autoUpdatesMinorCore'    => $minor,


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught NewfoldLabs\Container\NotFoundException: No entry was found for "comingSoon" identifier. in /.../vendor/newfold-labs/container/includes/Container.php:111
Stack trace:
#0 /.../vendor/newfold-labs/container/includes/Container.php(133): NewfoldLabs\Container\Container->raw('comingSoon')
#1 /.../inc/RestApi/SettingsController.php(178): NewfoldLabs\Container\Container->get('comingSoon')
#2 /.../inc/RestApi/SettingsController.php(51): Bluehost\RestApi\SettingsController->get_current_settings()
```

Recent commit https://github.com/bluehost/bluehost-wordpress-plugin/commit/70f155ca353b3349bacdf0569d46c517fe9ffc21 queries the container for `comingSoon` and calls methods `is_enabled()`, `enable()` and `disable()` on the result.

But where it is added to the container is `comingsoon` not `comingSoon`.

https://github.com/bluehost/bluehost-wordpress-plugin/blob/f51c559c1ba502f435b854b60e1527edc0edfff7/bootstrap.php#L63-L95

When I change it to use `comingSoon` in both places, the container returns the array that has been registered, but then the code attempts to call the `is_enabeld()` method which does not exist.

## Proposed changes

This PR changes `container()->get( 'comingSoon' )->is_enabled()` to `container()->has( 'comingSoon' )`.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Where `enable()` and `disable()` are called **will still cause a crash**.

The Coming Soon module itself uses lowercase `$container->has( 'comingsoon' )` at [includes/ComingSoon.php:46](https://github.com/newfold-labs/wp-module-coming-soon/blob/74a6eab836e1d339f3650c68e89fd51b574e46bb/includes/ComingSoon.php#L46)

I don't see a class with those methods so I'm not sure exactly how this should be working.
