### PR TITLE
fix plugin slug in action links filter

### DIFF
--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -25,7 +25,10 @@ final class Admin {
 		/* Load i18 files */
 		\add_action( 'init', array( __CLASS__, 'load_text_domain' ), 100 );
 		/* Add Links to WordPress Plugins list item. */
-		\add_filter( 'plugin_action_links_bluehost-wordpress-plugin/bluehost-wordpress-plugin.php', array( __CLASS__, 'actions' ) );
+		$plugin_basename = defined( 'BLUEHOST_PLUGIN_FILE' )
+			? plugin_basename( constant( 'BLUEHOST_PLUGIN_FILE' ) )
+			: 'bluehost-wordpress-plugin/bluehost-wordpress-plugin.php';
+		\add_filter( "plugin_action_links_{$plugin_basename}", array( __CLASS__, 'actions' ) );
 		/* Add inline style to hide subnav link */
 		\add_action( 'admin_head', array( __CLASS__, 'admin_nav_style' ) );
 

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -25,7 +25,7 @@ final class Admin {
 		/* Load i18 files */
 		\add_action( 'init', array( __CLASS__, 'load_text_domain' ), 100 );
 		/* Add Links to WordPress Plugins list item. */
-		\add_filter( 'plugin_action_links_wp-plugin-bluehost/wp-plugin-bluehost.php', array( __CLASS__, 'actions' ) );
+		\add_filter( 'plugin_action_links_bluehost-wordpress-plugin/bluehost-wordpress-plugin.php', array( __CLASS__, 'actions' ) );
 		/* Add inline style to hide subnav link */
 		\add_action( 'admin_head', array( __CLASS__, 'admin_nav_style' ) );
 


### PR DESCRIPTION
## Proposed changes

These links were already set up in the plugin but the plugin slug was incorrect in the hook so it was never loaded. This fixes that so they display (finally)

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
