### PR TITLE
Skip tests with woocommerce installation for unsupported WordPress and PHP versions

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -56,7 +56,8 @@ module.exports = defineConfig( {
 			// Exclude ecommerce tests for WordPress lower than 6.3 (6.2) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
 			if ( semver.satisfies( config.env.wpSemverVersion, '<6.3.0' ) || semver.satisfies( config.env.phpSemverVersion, '<7.4.0' )) {
 				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
-					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**'
+					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**',
+					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js'
 				] );
 			}
 


### PR DESCRIPTION
Skip tests from wp-module-ecommerce which needs woocommerce installed as a pre-requisite for WordPress version <6.3 and PHP version <7.4.

Should be merged along with **Ecommerce version bump 1.3.24** [#980](https://github.com/bluehost/bluehost-wordpress-plugin/pull/980)
