### PR TITLE
Render `bluehost-app-nav` messages in the app nav

### DIFF
--- a/src/app/components/app-nav/index.js
+++ b/src/app/components/app-nav/index.js
@@ -7,6 +7,12 @@ import { topRoutes, utilityRoutes } from 'App/data/routes';
 import { handleHelpLinksClick } from '../../util/helpers';
 import Logo from './logo';
 
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
+import { filter } from 'lodash';
+import { default as NewfoldNotifications } from '@modules/wp-module-notifications/assets/js/components/notifications/';
+
 export const SideNavHeader = () => {
 	return (
 		<header className="nfd-pt-2 nfd-px-3 nfd-mb-6 nfd-space-y-6">
@@ -146,6 +152,9 @@ export const SideNavMenuSubItem = ( { label, path, action } ) => {
 };
 
 export const SideNav = () => {
+	const location = useLocation();
+	const hashedPath = '#' + location.pathname;
+
 	return (
 		<aside className="wppbh-app-sidenav nfd-shrink-0 nfd-hidden min-[783px]:nfd-block nfd-pb-6 nfd-bottom-0 nfd-w-56">
 			<SidebarNavigation>
@@ -154,6 +163,20 @@ export const SideNav = () => {
 					<SideNavMenu />
 				</SidebarNavigation.Sidebar>
 			</SidebarNavigation>
+			<NewfoldNotifications
+				constants={ {
+					context: 'bluehost-app-nav',
+					page: hashedPath,
+				} }
+				methods={ {
+					apiFetch,
+					addQueryArgs,
+					classnames,
+					filter,
+					useState,
+					useEffect,
+				} }
+			/>
 		</aside>
 	);
 };

--- a/src/app/components/app-nav/index.js
+++ b/src/app/components/app-nav/index.js
@@ -1,17 +1,16 @@
 import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 import { useViewportMatch } from '@wordpress/compose';
+import { addQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
+import { filter } from 'lodash';
 import { Modal, SidebarNavigation } from '@newfold/ui-component-library';
+import { default as NewfoldNotifications } from '@modules/wp-module-notifications/assets/js/components/notifications/';
 import { NavLink, useLocation } from 'react-router-dom';
 import { Bars3Icon } from '@heroicons/react/24/outline';
 import { topRoutes, utilityRoutes } from 'App/data/routes';
 import { handleHelpLinksClick } from '../../util/helpers';
 import Logo from './logo';
-
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
-import classnames from 'classnames';
-import { filter } from 'lodash';
-import { default as NewfoldNotifications } from '@modules/wp-module-notifications/assets/js/components/notifications/';
 
 export const SideNavHeader = () => {
 	return (


### PR DESCRIPTION
## Proposed changes
Render notifications with `'bluehost-app-nav'` context in the app navigation.

More info can be found here: https://github.com/newfold-labs/wp-module-notifications/pull/23

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
