### PR TITLE
Add `tailwind.config.js` and `postcss.config.js` to `.distignore`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,7 @@ cypress.config.js
 set-latest-wp-version.js
 webpack.config.js
 tailwind.config.js
+postcss.config.js
 
 # File Types
 /*.json

--- a/.distignore
+++ b/.distignore
@@ -11,6 +11,7 @@ node_modules
 cypress.config.js
 set-latest-wp-version.js
 webpack.config.js
+tailwind.config.js
 
 # File Types
 /*.json


### PR DESCRIPTION
## Proposed changes

The plugin .zip file as downloaded from GitHub has two files that shouldn't be there: [tailwind.config.js](https://github.com/bluehost/bluehost-wordpress-plugin/blob/3.10.0/tailwind.config.js) and [postcss.config.js](https://github.com/bluehost/bluehost-wordpress-plugin/blob/3.10.0/postcss.config.js).

https://github.com/bluehost/bluehost-wordpress-plugin/releases/download/3.10.0/bluehost-wordpress-plugin.zip

<img width="369" alt="Screenshot 2024-05-14 at 9 33 12 AM" src="https://github.com/bluehost/bluehost-wordpress-plugin/assets/4720401/4bfbeffa-8323-4892-b38d-ca7f7d44b3aa">

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I didn't actually build an archive to test it.