### PR TITLE
remove teams message from release workflow

### DIFF
--- a/.github/workflows/upload-asset-on-release.yml
+++ b/.github/workflows/upload-asset-on-release.yml
@@ -127,8 +127,3 @@ jobs:
                -H "Content-Type: application/json" \
                --data '{"files":["https://hiive.cloud/workers/release-api/plugins/bluehost/bluehost-wordpress-plugin"]}'
 
-      - name: Send message to ms teams
-        uses: dhollerbach/actions.send-message-to-ms-teams@v3
-        with:
-          webhook: '${{ secrets.TEAMS_WEBHOOK_URL }}'
-          message: "Bluehost plugin version ${{ env.VERSION }} has been released!"


### PR DESCRIPTION
redundant since there is a satis notice already.

It usually just sends the message "Bluehost plugin version ${GITHUB_REF#refs/tags/*} has been released!" anyways, and it also failed in the release today. Rather than tinker I think we can just remove it from this workflow.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
