### PR TITLE
remove 'FREE Monthly Webinar: ' line from webinar component

### DIFF
--- a/src/app/components/webinars-banner/index.js
+++ b/src/app/components/webinars-banner/index.js
@@ -114,7 +114,7 @@ const WebinarsBanner = () => {
 
 					<div className="nfd-flex nfd-flex-col nfd-gap-4 nfd-w-full">
 						<Title as="h2" className="nfd-text-base">
-							FREE Monthly Webinar: { upcomingWebinar.title }
+							{ upcomingWebinar.title }
 						</Title>
 
 						{ ( upcomingWebinar.hasDescription ||

--- a/tests/cypress/integration/home.cy.js
+++ b/tests/cypress/integration/home.cy.js
@@ -62,10 +62,7 @@ describe( 'Home Page', function () {
 		);
 		cy.reload();
 		cy.get( '.wppbh-webinars-banner-section' )
-			.contains(
-				'h2',
-				'FREE Monthly Webinar: Build your brand with WordPress'
-			)
+			.contains( 'h2', 'Build your brand with WordPress' )
 			.scrollIntoView()
 			.should( 'be.visible' );
 	} );
@@ -73,10 +70,7 @@ describe( 'Home Page', function () {
 	it( 'Webinars Section Renders Correctly', () => {
 		// Title
 		cy.get( '.wppbh-webinars-banner-section' )
-			.contains(
-				'h2',
-				'FREE Monthly Webinar: Build your brand with WordPress'
-			)
+			.contains( 'h2', 'Build your brand with WordPress' )
 			.scrollIntoView()
 			.should( 'be.visible' );
 


### PR DESCRIPTION
Just removes the hard coded text from the component. The webinar title will now display exactly what the json indicates is the webinar title.

PRESS1-403

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
