### PR TITLE
Adding Sales Channel route under Store main menu item

### DIFF
--- a/src/app/data/routes.js
+++ b/src/app/data/routes.js
@@ -108,6 +108,13 @@ export const routes = [
 						title: __( 'Sales & Promotions', 'wp-plugin-bluehost' ),
 				  }
 				: null,
+			NewfoldRuntime.hasCapability( 'hasYithExtended' ) &&
+			NewfoldRuntime.hasCapability( 'hasEcomdash' )
+				? {
+						name: '/store/sales_channel',
+						title: __( 'Sales Channel', 'wp-plugin-bluehost' ),
+					}
+				: null,			
 			NewfoldRuntime.isWoo
 				? {
 						name: '/store/payments',

--- a/src/app/data/routes.js
+++ b/src/app/data/routes.js
@@ -113,8 +113,8 @@ export const routes = [
 				? {
 						name: '/store/sales_channel',
 						title: __( 'Sales Channel', 'wp-plugin-bluehost' ),
-					}
-				: null,			
+				  }
+				: null,
 			NewfoldRuntime.isWoo
 				? {
 						name: '/store/payments',


### PR DESCRIPTION
## Proposed changes

JIRA: https://jira.newfold.com/browse/PRESS0-1480

- To improve the visibility of the EcomDash plugin to our Ecommerce plus customers.
- If a customer has the Ecomdash entitlement, then the customer should see the Ecomdash landing page from the Store navigation under "Sales Channels".
- When a customer clicks on the page the first time, the CTA Get Started, it should open a new window with the Ecomdash onboarding.
- After a customer has setup the Ecomdash plugin, the customer should see the landing page with Open Dashboard as the CTA instead of the Get Started CTA.
- Related Ecommerce module [PR](https://github.com/newfold-labs/wp-module-ecommerce/pull/335)
- [Figma](https://www.figma.com/design/eKHvqb3T4Idairwe5TF29a/PRESS0-993-Ecomdash-Brand-Plugin-Integration?node-id=65-5155&t=JMlfLNHDNWphsmrm-1)

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
