### PR TITLE
bump Help Center to version 2.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "newfold-labs/wp-module-facebook": "^1.0.9",
     "newfold-labs/wp-module-features": "^1.4.2",
     "newfold-labs/wp-module-global-ctb": "^1.0.13",
-    "newfold-labs/wp-module-help-center": "^2.0.0",
+    "newfold-labs/wp-module-help-center": "^2.0.1",
     "newfold-labs/wp-module-loader": "^1.0.10",
     "newfold-labs/wp-module-marketplace": "^2.4.0",
     "newfold-labs/wp-module-migration": "^1.0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a35e219f351b0b0bcdce1cd743c30a",
+    "content-hash": "0dea33950ac0f63bb828da1cf04e544a",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -871,16 +871,16 @@
         },
         {
             "name": "newfold-labs/wp-module-help-center",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-help-center.git",
-                "reference": "da9d0d08d5067285c7d36d31b8db58434af2184e"
+                "reference": "9242f848c13b3f0ed17c30d452ea5807ce75fd4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-help-center/zipball/da9d0d08d5067285c7d36d31b8db58434af2184e",
-                "reference": "da9d0d08d5067285c7d36d31b8db58434af2184e",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-help-center/zipball/9242f848c13b3f0ed17c30d452ea5807ce75fd4a",
+                "reference": "9242f848c13b3f0ed17c30d452ea5807ce75fd4a",
                 "shasum": ""
             },
             "require": {
@@ -911,10 +911,10 @@
             ],
             "description": "HelpCenter",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-help-center/tree/2.0.0",
+                "source": "https://github.com/newfold-labs/wp-module-help-center/tree/2.0.1",
                 "issues": "https://github.com/newfold-labs/wp-module-help-center/issues"
             },
-            "time": "2024-05-29T14:37:29+00:00"
+            "time": "2024-07-18T13:12:42+00:00"
         },
         {
             "name": "newfold-labs/wp-module-install-checker",
@@ -2818,12 +2818,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "8a515648fece51efcf2e3f79330e0cbcb7c09645"
+                "reference": "80e489d7669e5f7a4c56ca250489a0450d3d3219"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/8a515648fece51efcf2e3f79330e0cbcb7c09645",
-                "reference": "8a515648fece51efcf2e3f79330e0cbcb7c09645",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/80e489d7669e5f7a4c56ca250489a0450d3d3219",
+                "reference": "80e489d7669e5f7a4c56ca250489a0450d3d3219",
                 "shasum": ""
             },
             "conflict": {
@@ -3223,7 +3223,7 @@
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
                 "open-web-analytics/open-web-analytics": "<1.7.4",
-                "opencart/opencart": "<=3.0.3.9|>=4",
+                "opencart/opencart": ">=0",
                 "openid/php-openid": "<2.3",
                 "openmage/magento-lts": "<20.5",
                 "opensolutions/vimbadmin": "<=3.0.15",
@@ -3621,7 +3621,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-17T15:06:03+00:00"
+            "time": "2024-07-18T00:16:06+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
## Proposed changes

With the release of WordPress 6.6, wp-polyfill has been removed from the React script dependency. This change was preventing the Help Center modal from appearing. A fix for this is mentioned here https://make.wordpress.org/core/2024/06/25/miscellaneous-developer-changes-in-wordpress-6-6/#obsolete-polyfills-dependencies-have-been-removed.

We have manually added `regenerator-runtime` library to the Help Center as recommended by the above link.

Jira Ticket : https://jira.newfold.com/browse/PRESS0-1793

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
