### PR TITLE
Correct misbranded spelling of WonderBlocks and DOM ID dupe

### DIFF
--- a/src/app/pages/settings/wonderBlocksSettings.js
+++ b/src/app/pages/settings/wonderBlocksSettings.js
@@ -18,17 +18,17 @@ const WonderBlocksSettings = () => {
 
 	const getWonderBlocksNoticeTitle = () => {
 		return wonderBlocks
-			? __( 'Wonder Blocks Enabled', 'wp-plugin-bluehost' )
-			: __( 'Wonder Blocks Disabled', 'wp-plugin-bluehost' );
+			? __( 'WonderBlocks Enabled', 'wp-plugin-bluehost' )
+			: __( 'WonderBlocks Disabled', 'wp-plugin-bluehost' );
 	};
 	const getWonderBlocksNoticeText = () => {
 		return wonderBlocks
 			? __(
-					'Create new content to see Wonder Blocks in action.',
+					'Create new content to see WonderBlocks in action.',
 					'wp-plugin-bluehost'
 			  )
 			: __(
-					'Wonder Blocks will no longer display.',
+					'WonderBlocks will no longer display.',
 					'wp-plugin-bluehost'
 			  );
 	};
@@ -78,9 +78,9 @@ const WonderBlocksSettings = () => {
 		<div className="nfd-flex nfd-flex-col nfd-gap-6">
 			<ToggleField
 				id="help-center-toggle"
-				label="Wonder Blocks"
+				label="WonderBlocks"
 				description={ __(
-					'Wonder Blocks provides a library of customizable block patterns and page templates.',
+					'WonderBlocks provides a library of customizable block patterns and page templates.',
 					'wp-plugin-bluehost'
 				) }
 				disabled={ wonderBlocksLocked }

--- a/src/app/pages/settings/wonderBlocksSettings.js
+++ b/src/app/pages/settings/wonderBlocksSettings.js
@@ -77,7 +77,7 @@ const WonderBlocksSettings = () => {
 	return (
 		<div className="nfd-flex nfd-flex-col nfd-gap-6">
 			<ToggleField
-				id="help-center-toggle"
+				id="wonderblocks-toggle"
 				label="WonderBlocks"
 				description={ __(
 					'WonderBlocks provides a library of customizable block patterns and page templates.',


### PR DESCRIPTION
## Proposed changes

* `WonderBlocks` branding correction made in module weeks before feature toggle launched
* Copy-pasted ID fix to prevent ID duplication in DOM

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
