### PR TITLE
Skip eCommerce module tests on  < wp 6.5

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -53,8 +53,8 @@ module.exports = defineConfig( {
 				}
 			}
 
-			// Exclude ecommerce tests for WordPress lower than 6.4 (6.3 or 6.2) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
-			if ( semver.satisfies( config.env.wpSemverVersion, '<6.4.0' ) || semver.satisfies( config.env.phpSemverVersion, '<7.4.0' )) {
+			// Exclude ecommerce tests for WordPress lower than 6.5 (6.4 or 6.3) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
+			if ( semver.satisfies( config.env.wpSemverVersion, '<6.5.0' ) || semver.satisfies( config.env.phpSemverVersion, '<7.4.0' )) {
 				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**',
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js',


### PR DESCRIPTION
## Proposed change
WooCommerce minimum supported version is 6.5

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
