### PR TITLE
Bump Onboarding to 2.3.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
     "newfold-labs/wp-module-marketplace": "^2.4.0",
     "newfold-labs/wp-module-migration": "^1.0.9",
     "newfold-labs/wp-module-notifications": "^1.5.0",
-    "newfold-labs/wp-module-onboarding": "^2.3.10",
+    "newfold-labs/wp-module-onboarding": "^2.3.11",
     "newfold-labs/wp-module-patterns": "^2.3.1",
     "newfold-labs/wp-module-performance": "2.0.0 as 1.9.9",
     "newfold-labs/wp-module-runtime": "^1.0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "817ca532adf7eaa11f5c9c62f05722f2",
+    "content-hash": "b53ece273e521ab3acae571783cec0b6",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1201,16 +1201,16 @@
         },
         {
             "name": "newfold-labs/wp-module-onboarding",
-            "version": "2.3.10",
+            "version": "2.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-onboarding.git",
-                "reference": "1cf639e7ed5f1b6f556daa2eba5039e08a7b7c3e"
+                "reference": "e9399e0ba9f0c185f630016e2bb68d29156dcd37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/1cf639e7ed5f1b6f556daa2eba5039e08a7b7c3e",
-                "reference": "1cf639e7ed5f1b6f556daa2eba5039e08a7b7c3e",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-onboarding/zipball/e9399e0ba9f0c185f630016e2bb68d29156dcd37",
+                "reference": "e9399e0ba9f0c185f630016e2bb68d29156dcd37",
                 "shasum": ""
             },
             "require": {
@@ -1256,10 +1256,10 @@
             ],
             "description": "Next-generation WordPress Onboarding for WordPress sites at Newfold Digital.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.10",
+                "source": "https://github.com/newfold-labs/wp-module-onboarding/tree/2.3.11",
                 "issues": "https://github.com/newfold-labs/wp-module-onboarding/issues"
             },
-            "time": "2024-08-05T10:56:44+00:00"
+            "time": "2024-08-09T10:20:09+00:00"
         },
         {
             "name": "newfold-labs/wp-module-onboarding-data",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -58,6 +58,7 @@ module.exports = defineConfig( {
 				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**',
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js',
+					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/ecommerce-next-steps.cy.js', // Skip this since Onboarding does not support this version
 					'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/**' // Onboarding requires WP 6.5 or greater, as it uses the Wonder Theme which has the same requirement
 				] );
 			}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -53,12 +53,12 @@ module.exports = defineConfig( {
 				}
 			}
 
-			// Exclude ecommerce tests for WordPress lower than 6.5 (6.4 or 6.3) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
+			// Exclude Onboarding and ecommerce tests for WordPress lower than 6.5 (6.4 or 6.3) or PHP lower than 7.4 (7.1, 7.2 and 7.3)
 			if ( semver.satisfies( config.env.wpSemverVersion, '<6.5.0' ) || semver.satisfies( config.env.phpSemverVersion, '<7.4.0' )) {
 				config.excludeSpecPattern = config.excludeSpecPattern.concat( [
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Site-Capabilities/**',
 					'vendor/newfold-labs/wp-module-ecommerce/tests/cypress/integration/Home/homePageWithWoo.cy.js',
-					'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/5-AI-SiteGen-onboarding-flow/*.cy.js' // Works but failing on cypress
+					'vendor/newfold-labs/wp-module-onboarding/tests/cypress/integration/**' // Onboarding requires WP 6.5 or greater, as it uses the Wonder Theme which has the same requirement
 				] );
 			}
 


### PR DESCRIPTION
## Proposed changes

This release updates the minimum compatibility of Onboarding to WP 6.5 or greater, as Onboarding uses the Wonder Theme, which has the same requirement.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
