### PR TITLE
Fix typo in empty trash SelectField label

### DIFF
--- a/src/app/pages/settings/contentSettings.js
+++ b/src/app/pages/settings/contentSettings.js
@@ -157,7 +157,7 @@ const EmptyTrash = ( { setError, notify } ) => {
 		<SelectField
 			id="empty-trash-select"
 			label={ __(
-				'Number of weeks inbetween emptying trash ',
+				'Number of weeks in between emptying trash ',
 				'wp-plugin-bluehost'
 			) }
 			description={


### PR DESCRIPTION
## Proposed changes

Fixes `inbetween` label in settings -- should be `in between`.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
