### PR TITLE
Remove the site_capabilities filter

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -203,22 +203,3 @@ if ( is_admin() ) {
 
 // Instantiate the Features singleton
 Features::getInstance();
-
-/**
- * Temporary hook to filter the capabilities in case they are empty
- * This is to fix an issue where the migration value is not found on new sites
- * Temporary fix to keep things working while we determing the root cause
- */
-add_filter(
-	'transient_nfd_site_capabilities',
-	function ( $transient ) {
-		if ( empty( $transient ) ) {
-			return array(
-				'canMigrateSite' => true,
-			);
-		}
-		return $transient;
-	},
-	10,
-	2
-);

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     "newfold-labs/wp-module-atomic": "^1.3.0",
     "newfold-labs/wp-module-coming-soon": "^1.2.5",
     "newfold-labs/wp-module-context": "^1.0.1",
-    "newfold-labs/wp-module-data": "^2.6.1",
+    "newfold-labs/wp-module-data": "^2.6.2",
     "newfold-labs/wp-module-deactivation": "^1.2.3",
     "newfold-labs/wp-module-ecommerce": "^1.3.40",
     "newfold-labs/wp-module-facebook": "^1.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed08e03d608562850e8d0e852b172450",
+    "content-hash": "11c7f52792a412c64915f7fcfa8da604",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -504,16 +504,16 @@
         },
         {
             "name": "newfold-labs/wp-module-data",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-data.git",
-                "reference": "49dc91eec8053872354db9cddd355e45f2de49e4"
+                "reference": "91d1b03162f23b7b8bd3a41d9496eb8017df0051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/49dc91eec8053872354db9cddd355e45f2de49e4",
-                "reference": "49dc91eec8053872354db9cddd355e45f2de49e4",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-data/zipball/91d1b03162f23b7b8bd3a41d9496eb8017df0051",
+                "reference": "91d1b03162f23b7b8bd3a41d9496eb8017df0051",
                 "shasum": ""
             },
             "require": {
@@ -595,10 +595,10 @@
             ],
             "description": "Newfold Data Module",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.6.1",
+                "source": "https://github.com/newfold-labs/wp-module-data/tree/2.6.2",
                 "issues": "https://github.com/newfold-labs/wp-module-data/issues"
             },
-            "time": "2024-07-25T16:37:25+00:00"
+            "time": "2024-08-16T14:18:26+00:00"
         },
         {
             "name": "newfold-labs/wp-module-deactivation",


### PR DESCRIPTION
## Proposed changes
Moves the filter from the BH plugin's `bootstrap.php` file to the data module, where other filters are located, and includes the `is_callable` check. This approach is much safer.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
