### PR TITLE
Fix lint issues with i18n strings

### DIFF
--- a/src/app/components/errorCard/index.js
+++ b/src/app/components/errorCard/index.js
@@ -45,7 +45,8 @@ const ErrorCard = ( { error, className, notice = 'Error!' } ) => {
 				<p>
 					{ error && error.message ? error.message : '' }
 					{ error && error.data
-						? __( ' Error code: ', 'wp-plugin-bluehost' ) +
+						? __( 'Error code:', 'wp-plugin-bluehost' ) +
+						  ' ' +
 						  error.data.status
 						: '' }
 				</p>

--- a/src/app/pages/home/myProductsSection.js
+++ b/src/app/pages/home/myProductsSection.js
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/i18n-no-flanking-whitespace */
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
 import { NewfoldRuntime } from '@newfold-labs/wp-module-runtime';

--- a/src/app/pages/settings/commentSettings.js
+++ b/src/app/pages/settings/commentSettings.js
@@ -1,3 +1,4 @@
+/* global sprintf */
 import { useState } from '@wordpress/element';
 import { useUpdateEffect } from 'react-use';
 import {
@@ -9,7 +10,6 @@ import {
 import AppStore from '../../data/store';
 import { bluehostSettingsApiFetch } from '../../util/helpers';
 import { useNotification } from 'App/components/notifications';
-
 const OldPostsComments = ( { setError, notify } ) => {
 	const { store, setStore } = useContext( AppStore );
 	const [ disableCommentsOldPosts, setDisableCommentsOldPosts ] = useState(
@@ -78,37 +78,32 @@ const CloseCommentsDays = ( { setError, notify } ) => {
 	);
 
 	const closeCommentsDaysNoticeTitle = () => {
-		return __( 'Comments setting saved ', 'wp-plugin-bluehost' );
+		return __( 'Comments setting saved', 'wp-plugin-bluehost' );
 	};
 
 	const closeCommentsDaysNoticeText = () => {
-		//`Comments on posts are disabled after ${closeCommentsDays} days.`
-		return (
-			__(
-				'Comments on posts are disabled after ',
-				'wp-plugin-bluehost'
-			) +
-			closeCommentsDays +
+		return sprintf(
+			//translators: %s: number of days. `Comments on posts are disabled after ${closeCommentsDays} days.`
 			_n(
-				' day.',
-				' days.',
+				'Comments on posts are disabled after %s day.',
+				'Comments on posts are disabled after %s days.',
 				parseInt( closeCommentsDays ),
 				'wp-plugin-bluehost'
-			)
+			),
+			closeCommentsDays
 		);
 	};
 
 	const closeCommentsDaysLabelText = () => {
-		//`Close comments after ${closeCommentsDays} days.`
-		return (
-			__( 'Close comments after ', 'wp-plugin-bluehost' ) +
-			closeCommentsDays +
+		return sprintf(
+			//translators: %s: number of days. `Close comments after ${closeCommentsDays} days.`
 			_n(
-				' day.',
-				' days.',
+				'Close comments after %s day.',
+				'Close comments after %s days.',
 				parseInt( closeCommentsDays ),
 				'wp-plugin-bluehost'
-			)
+			),
+			closeCommentsDays
 		);
 	};
 
@@ -178,16 +173,15 @@ const CommentsPerPage = ( { setError, notify } ) => {
 	};
 
 	const commentsPerPageNoticeText = () => {
-		//`Posts will display ${commentsPerPage} comments at a time.`
-		return (
-			__( 'Posts will display ', 'wp-plugin-bluehost' ) +
-			commentsPerPage +
+		return sprintf(
+			//translators: %s: number of comments. `Posts will display ${commentsPerPage} comments at a time.`
 			_n(
-				' comment at a time.',
-				' comments at a time.',
+				'Posts will display %s comment at a time.',
+				'Posts will display %s comments at a time.',
 				parseInt( commentsPerPage ),
 				'wp-plugin-bluehost'
-			)
+			),
+			commentsPerPage
 		);
 	};
 

--- a/src/app/pages/settings/contentSettings.js
+++ b/src/app/pages/settings/contentSettings.js
@@ -1,3 +1,4 @@
+/* global sprintf */
 import { useState } from '@wordpress/element';
 import { useUpdateEffect } from 'react-use';
 import { Alert, Container, SelectField } from '@newfold/ui-component-library';
@@ -13,22 +14,19 @@ const EmptyTrash = ( { setError, notify } ) => {
 	let numTrashWeeks = Math.floor( emptyTrashDays / 7 );
 
 	const emptyTrashNoticeTitle = () => {
-		return __( 'Trash setting saved ', 'wp-plugin-bluehost' );
+		return __( 'Trash setting saved', 'wp-plugin-bluehost' );
 	};
 
 	const emptyTrashNoticeText = () => {
-		return (
-			__(
-				'The trash will automatically empty every ',
-				'wp-plugin-bluehost'
-			) +
-			numTrashWeeks +
+		return sprintf(
+			//translators: %s: number of weeks. `The trash will automatically empty every ${numTrashWeeks} weeks.`
 			_n(
-				' week.',
-				' weeks.',
+				'The trash will automatically empty every %s week.',
+				'The trash will automatically empty every %s weeks.',
 				parseInt( numTrashWeeks ),
 				'wp-plugin-bluehost'
-			)
+			),
+			numTrashWeeks
 		);
 	};
 
@@ -66,22 +64,10 @@ const EmptyTrash = ( { setError, notify } ) => {
 		<SelectField
 			id="empty-trash-select"
 			label={ __(
-				'Number of weeks in between emptying trash ',
+				'Number of weeks in between emptying trash',
 				'wp-plugin-bluehost'
 			) }
-			description={
-				__(
-					'The trash will automatically empty every ',
-					'wp-plugin-bluehost'
-				) +
-				numTrashWeeks +
-				_n(
-					' week.',
-					' weeks.',
-					parseInt( numTrashWeeks ),
-					'wp-plugin-bluehost'
-				)
-			}
+			description={ emptyTrashNoticeText() }
 			value={ emptyTrashDays }
 			selectedLabel={ numTrashWeeks }
 			options={ [
@@ -104,7 +90,7 @@ const ContentSettings = () => {
 		<Container.SettingsField
 			title={ __( 'Content Options', 'wp-plugin-bluehost' ) }
 			description={ __(
-				'Controls for content revisions and how often to empty the trash.',
+				'Controls for how often to empty the trash.',
 				'wp-plugin-bluehost'
 			) }
 		>


### PR DESCRIPTION
## Proposed changes

Some files that were touched by the 3.14.11 release had linting issues that snuck through. It seems to be a new rule since the files were last touched, but this fixes them. 

The fix involves using sprintf for strings with vars rather than stitching strings manually with spaces.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
