### PR TITLE
Update burst safety mode page to enqueue CSS rather than just echoing it

### DIFF
--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -36,6 +36,8 @@ define( 'BLUEHOST_PLUGIN_VERSION', '3.14.12' );
 define( 'BLUEHOST_PLUGIN_FILE', __FILE__ );
 define( 'BLUEHOST_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLUEHOST_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'BLUEHOST_BUILD_DIR', BLUEHOST_PLUGIN_DIR . 'build/' . BLUEHOST_PLUGIN_VERSION );
+define( 'BLUEHOST_BUILD_URL', BLUEHOST_PLUGIN_URL . 'build/' . BLUEHOST_PLUGIN_VERSION );
 if ( ! defined( 'NFD_HIIVE_URL' ) ) {
 	define( 'NFD_HIIVE_URL', 'https://hiive.cloud/api' );
 }
@@ -48,9 +50,6 @@ if ( defined( 'BURST_SAFETY_MODE' ) && BURST_SAFETY_MODE ) {
 	// Short-circuit all plugin functionality
 	return;
 }
-
-define( 'BLUEHOST_BUILD_DIR', BLUEHOST_PLUGIN_DIR . 'build/' . BLUEHOST_PLUGIN_VERSION );
-define( 'BLUEHOST_BUILD_URL', BLUEHOST_PLUGIN_URL . 'build/' . BLUEHOST_PLUGIN_VERSION );
 
 global $pagenow;
 if ( 'plugins.php' === $pagenow ) {
@@ -69,15 +68,15 @@ if ( 'plugins.php' === $pagenow ) {
 require_once BLUEHOST_PLUGIN_DIR . '/inc/plugin-nfd-compat-check.php';
 $nfd_plugins_check = new NFD_Plugin_Compat_Check( BLUEHOST_PLUGIN_FILE );
 // Defer to Incompatible plugin, self-deactivate
-$nfd_plugins_check->incompatible_plugins = array();
+$nfd_plugins_check->incompatible_plugins = [];
 // Deactivate legacy plugin
-$nfd_plugins_check->legacy_plugins = array(
+$nfd_plugins_check->legacy_plugins = [
 	'The MOJO Marketplace'     => 'mojo-marketplace-wp-plugin/mojo-marketplace.php',
 	'The MOJO Plugin'          => 'wp-plugin-mojo/wp-plugin-mojo.php',
 	'The HostGator Plugin'     => 'wp-plugin-hostgator/wp-plugin-hostgator.php',
 	'The Web.com Plugin'       => 'wp-plugin-web/wp-plugin-web.php',
 	'The Crazy Domains Plugin' => 'wp-plugin-web/wp-plugin-crazy-domains.php',
-);
+];
 // Check plugin requirements
 $pass_nfd_check = $nfd_plugins_check->check_plugin_requirements();
 

--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -68,15 +68,15 @@ if ( 'plugins.php' === $pagenow ) {
 require_once BLUEHOST_PLUGIN_DIR . '/inc/plugin-nfd-compat-check.php';
 $nfd_plugins_check = new NFD_Plugin_Compat_Check( BLUEHOST_PLUGIN_FILE );
 // Defer to Incompatible plugin, self-deactivate
-$nfd_plugins_check->incompatible_plugins = [];
+$nfd_plugins_check->incompatible_plugins = array();
 // Deactivate legacy plugin
-$nfd_plugins_check->legacy_plugins = [
+$nfd_plugins_check->legacy_plugins = array(
 	'The MOJO Marketplace'     => 'mojo-marketplace-wp-plugin/mojo-marketplace.php',
 	'The MOJO Plugin'          => 'wp-plugin-mojo/wp-plugin-mojo.php',
 	'The HostGator Plugin'     => 'wp-plugin-hostgator/wp-plugin-hostgator.php',
 	'The Web.com Plugin'       => 'wp-plugin-web/wp-plugin-web.php',
 	'The Crazy Domains Plugin' => 'wp-plugin-web/wp-plugin-crazy-domains.php',
-];
+);
 // Check plugin requirements
 $pass_nfd_check = $nfd_plugins_check->check_plugin_requirements();
 

--- a/inc/alt-experience/init.php
+++ b/inc/alt-experience/init.php
@@ -8,10 +8,21 @@ add_action(
 			'manage_options',
 			'bluehost',
 			function () {
-				echo '<style>';
-				echo file_get_contents( BLUEHOST_PLUGIN_DIR . 'build/' . BLUEHOST_PLUGIN_VERSION . '/index.css' );
-				echo '</style>';
-				echo file_get_contents( __DIR__ . '/index.html' );
+				$version = BLUEHOST_PLUGIN_VERSION;
+				$asset_file = BLUEHOST_BUILD_DIR . '/index.asset.php';
+				if ( is_readable( $asset_file ) ) {
+					$asset = include_once $asset_file;
+					$version = $asset['version'];
+				}
+
+				wp_enqueue_style(
+					'bluehost-style',
+					BLUEHOST_BUILD_URL . '/index.css',
+					[ 'wp-components' ],
+					$version
+				);
+
+				echo file_get_contents( __DIR__ . '/index.html' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			},
 			'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA0MCA0MCI+CiAgICA8cGF0aCBmaWxsPSIjYTdhYWFkIiBkPSJNNCA0aDguOTMzdjguOTIzSDRWNFptMTEuNTMgMGg4Ljk0djguOTIzaC04Ljk0VjRabTExLjUzMSAwSDM2djguOTIzaC04LjkzOVY0Wk00IDE1LjUzOGg4LjkzM3Y4LjkyNEg0di04LjkyNFptMTEuNTMgMGg4Ljk0djguOTI0aC04Ljk0di04LjkyNFptMTEuNTMxIDBIMzZ2OC45MjRoLTguOTM5di04LjkyNFpNNCAyNy4wNzdoOC45MzNWMzZINHYtOC45MjNabTExLjUzIDBoOC45NFYzNmgtOC45NHYtOC45MjNabTExLjUzMSAwSDM2VjM2aC04LjkzOXYtOC45MjNaIi8+Cjwvc3ZnPg==',
 			1

--- a/inc/alt-experience/init.php
+++ b/inc/alt-experience/init.php
@@ -18,7 +18,7 @@ add_action(
 				wp_enqueue_style(
 					'bluehost-style',
 					BLUEHOST_BUILD_URL . '/index.css',
-					[ 'wp-components' ],
+					array( 'wp-components' ),
 					$version
 				);
 


### PR DESCRIPTION
- `define`s are moved to be able to use them in the alt-experience file and to make them fit in better with the rest
- condensed the comments of the loading
- enqueued the styles rather than just echoing the CSS