### PR TITLE
Bump Installer Module to `v1.2.1`

### DIFF
--- a/bluehost-wordpress-plugin.php
+++ b/bluehost-wordpress-plugin.php
@@ -12,7 +12,7 @@
  * Plugin URI:        https://bluehost.com
  * Update URI:        https://github.com/bluehost/bluehost-wordpress-plugin
  * Description:       WordPress plugin that integrates a WordPress site with the Bluehost control panel, including performance, security, and update features.
- * Version:           3.15.0
+ * Version:           3.15.1
  * Requires at least: 6.4
  * Requires PHP:      7.3
  * Tested up to:      6.6.2
@@ -32,7 +32,7 @@ if ( defined( 'BLUEHOST_PLUGIN_VERSION' ) ) {
 }
 
 // Define constants
-define( 'BLUEHOST_PLUGIN_VERSION', '3.15.0' );
+define( 'BLUEHOST_PLUGIN_VERSION', '3.15.1' );
 define( 'BLUEHOST_PLUGIN_FILE', __FILE__ );
 define( 'BLUEHOST_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'BLUEHOST_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
     "i18n-json": "Generate new language .json files."
   },
   "require-dev": {
-    "roave/security-advisories": "dev-latest",
     "newfold-labs/wp-php-standards": "^1.2.4",
+    "roave/security-advisories": "dev-latest",
     "wp-cli/i18n-command": "^2.6.3",
     "wp-phpunit/wp-phpunit": "^6.6.2"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -1289,12 +1289,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-installer.git",
-                "reference": "4c5b0e49c53eb34feb5b438175d114dd2570d013"
+                "reference": "decd749fb6718fcba0993580d078dba788d6620e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/4c5b0e49c53eb34feb5b438175d114dd2570d013",
-                "reference": "4c5b0e49c53eb34feb5b438175d114dd2570d013",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/decd749fb6718fcba0993580d078dba788d6620e",
+                "reference": "decd749fb6718fcba0993580d078dba788d6620e",
                 "shasum": ""
             },
             "require": {
@@ -1327,7 +1327,7 @@
                 "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.2.1",
                 "issues": "https://github.com/newfold-labs/wp-module-installer/issues"
             },
-            "time": "2024-10-23T23:13:54+00:00"
+            "time": "2024-10-25T08:25:42+00:00"
         },
         {
             "name": "newfold-labs/wp-module-loader",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f052fe743bdff597a3bcfca1610bc2b",
+    "content-hash": "f671e6118ce8549527f1865a3f17f3fd",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/composer.lock
+++ b/composer.lock
@@ -3623,12 +3623,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "51e3fa290bca57eca7ba6c261b8a1278eb13a98a"
+                "reference": "bae581ca4125f92b1ad4d316ac691fa2d5231649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/51e3fa290bca57eca7ba6c261b8a1278eb13a98a",
-                "reference": "51e3fa290bca57eca7ba6c261b8a1278eb13a98a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/bae581ca4125f92b1ad4d316ac691fa2d5231649",
+                "reference": "bae581ca4125f92b1ad4d316ac691fa2d5231649",
                 "shasum": ""
             },
             "conflict": {
@@ -3636,7 +3636,7 @@
                 "admidio/admidio": "<4.3.12",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<2.2",
-                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.04.6",
+                "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
                 "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
                 "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
                 "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9|==2024.04.1",
@@ -3680,7 +3680,7 @@
                 "barrelstrength/sprout-forms": "<3.9",
                 "barryvdh/laravel-translation-manager": "<0.6.2",
                 "barzahlen/barzahlen-php": "<2.0.1",
-                "baserproject/basercms": "<5.0.9",
+                "baserproject/basercms": "<=5.1.1",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "bbpress/bbpress": "<2.6.5",
                 "bcosca/fatfree": "<3.7.2",
@@ -3965,6 +3965,7 @@
                 "lms/routes": "<2.1.1",
                 "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
                 "luyadev/yii-helpers": "<1.2.1",
+                "maestroerror/php-heic-to-jpg": "<1.0.5",
                 "magento/community-edition": "<2.4.5|==2.4.5|>=2.4.5.0-patch1,<2.4.5.0-patch10|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch8|>=2.4.7.0-beta1,<2.4.7.0-patch3",
                 "magento/core": "<=1.9.4.5",
                 "magento/magento1ce": "<1.9.4.3-dev",
@@ -4125,7 +4126,7 @@
                 "processwire/processwire": "<=3.0.229",
                 "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
                 "propel/propel1": ">=1,<=1.7.1",
-                "pterodactyl/panel": "<1.11.6",
+                "pterodactyl/panel": "<1.11.8",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
@@ -4447,7 +4448,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-21T20:05:20+00:00"
+            "time": "2024-10-24T22:04:53+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -1285,16 +1285,16 @@
         },
         {
             "name": "newfold-labs/wp-module-installer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/newfold-labs/wp-module-installer.git",
-                "reference": "decd749fb6718fcba0993580d078dba788d6620e"
+                "reference": "4b994a784f1de5c80dcf274e51ab34f083e4a26d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/decd749fb6718fcba0993580d078dba788d6620e",
-                "reference": "decd749fb6718fcba0993580d078dba788d6620e",
+                "url": "https://api.github.com/repos/newfold-labs/wp-module-installer/zipball/4b994a784f1de5c80dcf274e51ab34f083e4a26d",
+                "reference": "4b994a784f1de5c80dcf274e51ab34f083e4a26d",
                 "shasum": ""
             },
             "require": {
@@ -1324,10 +1324,10 @@
             ],
             "description": "An installer for WordPress plugins and themes.",
             "support": {
-                "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.2.1",
+                "source": "https://github.com/newfold-labs/wp-module-installer/tree/1.2.2",
                 "issues": "https://github.com/newfold-labs/wp-module-installer/issues"
             },
-            "time": "2024-10-25T08:25:42+00:00"
+            "time": "2024-10-25T14:26:52+00:00"
         },
         {
             "name": "newfold-labs/wp-module-loader",

--- a/languages/wp-plugin-bluehost.pot
+++ b/languages/wp-plugin-bluehost.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL 2.0 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: The Bluehost Plugin 3.15.0\n"
+"Project-Id-Version: The Bluehost Plugin 3.15.1\n"
 "Report-Msgid-Bugs-To: https://github.com/bluehost/bluehost-wordpress-plugin/issues\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -86,43 +86,43 @@ msgstr ""
 
 #: inc/Admin.php:72
 #: inc/Admin.php:289
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Home"
 msgstr ""
 
 #: inc/Admin.php:75
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Pages & Posts"
 msgstr ""
 
 #: inc/Admin.php:78
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Store"
 msgstr ""
 
 #: inc/Admin.php:81
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Marketplace"
 msgstr ""
 
 #: inc/Admin.php:86
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "My Plugins & Tools"
 msgstr ""
 
 #: inc/Admin.php:92
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Performance"
 msgstr ""
 
 #: inc/Admin.php:96
 #: inc/Admin.php:290
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Settings"
 msgstr ""
 
 #: inc/Admin.php:101
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Staging"
 msgstr ""
 
@@ -196,221 +196,221 @@ msgstr ""
 msgid "Auto-updates enabled"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Bluehost WordPress Plugin"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Oh No, An Error!"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "You found an error, please refresh the page and try again!"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "If the error persists, please contact support."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Error code:"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Bluehost Account"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "There's nothing here!"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Products & Services"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Sales & Promotions"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Sales Channel"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Payments"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Store Details"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Help with WordPress"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Admin"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "The staging feature provides a way to copy a site to test new updates, features or content."
 msgstr ""
 
-#: build/3.15.0/index.js:1
-#: build/3.15.0/index.js:9
+#: build/3.15.1/index.js:1
+#: build/3.15.1/index.js:9
 msgid "Sorry, that is not allowed."
 msgstr ""
 
-#: build/3.15.0/index.js:1
-#: build/3.15.0/index.js:9
+#: build/3.15.1/index.js:1
+#: build/3.15.1/index.js:9
 msgid "This feature cannot currently be modified."
 msgstr ""
 
-#: build/3.15.0/index.js:1
-#: build/3.15.0/index.js:9
+#: build/3.15.1/index.js:1
+#: build/3.15.1/index.js:9
 msgid "Oops! Something went wrong. Please try again."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Phone"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Call Us"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Chat"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Chat with one of our friendly Customer Care Specialists, as we are waiting to help. Open 24 hours - 7 days."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Live Chat"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Tweet"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Find our team at @bluehost for updates on our products and support from our team."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Tweet Us"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "YouTube"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Find tutorials, answers, interviews and guides on our YouTube channel."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Watch Now"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Knowledge Base"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Articles, guides, how-tos, instructions, and answers to our client's most frequently asked questions."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Visit Knowledge Base"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Resources"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Boost your online knowledge and get ahead of the competition."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Explore Resources"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Events and Webinars"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Team Bluehost organizes multiple webinars and events throughout the year. We are also sponsors and speak at most WordCamps across the world. Join us at our next event!"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "More Info"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Bluehost Website"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Not finding what you need? Visit our website for more information about our products and services."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Go to Bluehost"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Site Pages"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Edit your homepage and other existing pages or add new pages to your site."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "View all"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Add New"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "The Help Center provides guided, step-by-step assistance as you build your site."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Site Status"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Not Live"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Live"
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Your Bluehost Coming Soon page lets you hide your site from visitors while you make the magic happen."
 msgstr ""
 
-#: build/3.15.0/index.js:1
+#: build/3.15.1/index.js:1
 msgid "Your website is currently displaying a \"Coming Soon\" page."
 msgstr ""
 
 #. translators: %s: number of weeks. `The trash will automatically empty every ${numTrashWeeks} weeks.`
-#: build/3.15.0/index.js:3
+#: build/3.15.1/index.js:3
 msgid "The trash will automatically empty every %s week."
 msgid_plural "The trash will automatically empty every %s weeks."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %s: number of comments. `Posts will display ${commentsPerPage} comments at a time.`
-#: build/3.15.0/index.js:9
+#: build/3.15.1/index.js:9
 msgid "WonderBlocks provides a library of customizable block patterns and page templates."
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bluehost-wordpress-plugin",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bluehost-wordpress-plugin",
-            "version": "3.15.0",
+            "version": "3.15.1",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "@heroicons/react": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bluehost-wordpress-plugin",
-    "version": "3.15.0",
+    "version": "3.15.1",
     "description": "WordPress plugin that integrates your WordPress site with the Bluehost control panel, including performance, security, and update features.",
     "author": {
         "name": "Bluehost",


### PR DESCRIPTION
## Proposed changes

This uses the re-released installer module `v 1.2.1` that has a fix for the version mismatch. 

PR for fix: https://github.com/newfold-labs/wp-module-installer/pull/41
Release Notes: https://github.com/newfold-labs/wp-module-installer/releases/tag/1.2.1

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
