### PR TITLE
remove performance module alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
     "newfold-labs/wp-module-onboarding": "^2.5.0",
     "newfold-labs/wp-module-onboarding-data": "^1.2.1",
     "newfold-labs/wp-module-patterns": "^2.6.0",
-    "newfold-labs/wp-module-performance": "2.0.1 as 1.9.9",
+    "newfold-labs/wp-module-performance": "2.0.1",
     "newfold-labs/wp-module-pls": "^1.0.0",
     "newfold-labs/wp-module-runtime": "^1.0.11",
     "newfold-labs/wp-module-secure-passwords": "^1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41b79e4719f77b057090712226555a02",
+    "content-hash": "454bbd03b8bbb41b067a96b6a1f5e6e5",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -5041,14 +5041,7 @@
             "time": "2024-07-17T01:13:44+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "newfold-labs/wp-module-performance",
-            "version": "2.0.1.0",
-            "alias": "1.9.9",
-            "alias_normalized": "1.9.9.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "roave/security-advisories": 20


### PR DESCRIPTION
## Proposed changes

Now that onboarding has updated the performance module version in its requirements we can remove the alias to the 2.x major update.


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
