### PR TITLE
Fix/plugins loaded priority for cache types

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,7 +11,6 @@ use WP_Forge\WPUpdateHandler\PluginUpdater;
 use WP_Forge\UpgradeHandler\UpgradeHandler;
 use NewfoldLabs\WP\ModuleLoader\Container;
 use NewfoldLabs\WP\ModuleLoader\Plugin;
-use NewfoldLabs\WP\Context\Context;
 use NewfoldLabs\WP\Module\Features\Features;
 use function NewfoldLabs\WP\ModuleLoader\container as setContainer;
 use function NewfoldLabs\WP\Context\setContext;
@@ -80,8 +79,7 @@ add_action(
 			$bluehost_module_container->set( 'cache_types', $cache_types );
 			$bluehost_module_container->set( 'marketplace_brand', $marketplace_brand );
 		}
-	},
-	11
+	}
 );
 
 // Properly get branding links depending on market


### PR DESCRIPTION
## Proposed changes

On bootstrap.php the cache_types is added to the container in the action plugins_loaded with priority 11, but this fire after the performance module so that information is not present when the performance module check for that datas. Removing the priority will provide the needed information and the getContext also seem to work normally.

Due to data not present, the cache types classes are not correctly loaded, se when one changes the level cache option in the Perfomance panel the event will not trigger the Option listeners and no changes apply.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
