### PR TITLE
Fix 'isJarvis' check that always returned true

### DIFF
--- a/src/app/util/helpers.js
+++ b/src/app/util/helpers.js
@@ -223,8 +223,8 @@ export const handleHelpLinksClick = () => {
  * @return {boolean} Whether or not this is a jarvis site.
  */
 export const isJarvis = () => {
-	if ( NewfoldRuntime.hasCapability( 'isJarvis' ) ) {
-		return window.NewfoldRuntime.capabilities.isJarvis;
+	if ( window.NewfoldRuntime.capabilities.hasOwnProperty( 'isJarvis' ) ) {
+		return NewfoldRuntime.hasCapability( 'isJarvis' );
 	}
 	return true;
 };


### PR DESCRIPTION
## Proposed changes

Problem: The `isJarvis` Check that is defined in the **helper util** function checks for https://github.com/bluehost/bluehost-wordpress-plugin/blob/b12e1d7c561c1047293b9e95c5bf14c2814ca00d/src/app/util/helpers.js#L226 before sending the actual capability data and the way this function is defined is it returns the actual value itself and not 'if the key exists in the capabilities' [Reference](https://github.com/newfold-labs/wp-module-runtime/blob/c63ba65520c917a9be99a492bc824f4a54c2daef/src/index.js#L5-L7) 

Due to this even if the **isJarvis** capability is **_switched off_** in a prod site, the `isJarvis function` returned **true**, as the if case inside the function fails and the default return is true.

This created an issue where in **Bluehost_India** customers the link to **Bluehost Account** in the plugin was incorrect. [PRESS0-2354](https://jira.newfold.com/browse/PRESS0-2354)
<img width="1246" alt="Screenshot 2024-12-10 at 13 33 36" src="https://github.com/user-attachments/assets/0f63b365-ea0d-4684-88a5-20036fbbec79">


## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
