### PR TITLE
Migrate repo to Newfold labs org

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -137,7 +137,7 @@ $bluehost_module_container->set(
 setContainer( $bluehost_module_container );
 
 // Set up the updater endpoint and map values
-$updateurl     = 'https://hiive.cloud/workers/release-api/plugins/bluehost/bluehost-wordpress-plugin'; // Custom API GET endpoint
+$updateurl     = 'https://hiive.cloud/workers/release-api/plugins/newfold-labs/wp-plugin-bluehost?slug=bluehost-wordpress-plugin&file=bluehost-wordpress-plugin.php '; // Custom API GET endpoint
 $pluginUpdater = new PluginUpdater( BLUEHOST_PLUGIN_FILE, $updateurl );
 $pluginUpdater->setDataMap(
 	array(


### PR DESCRIPTION
## Proposed changes

This changes the update url to the new endpoint. 

This is in preparation for migrating the repo to the newfold-labs org. Once this merge is integrated and a release is tagged, the distributed plugin installations will begin looking for updates at the new URL and immediately find the major update.

See https://jira.newfold.com/browse/PRESS10-41 and https://github.com/newfold-labs/wp-plugin-bluehost/pull/1

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
