### PR TITLE
Add IDs to settings sections

### DIFF
--- a/src/app/pages/settings/index.js
+++ b/src/app/pages/settings/index.js
@@ -18,6 +18,7 @@ const Settings = () => {
 						'This is where you can manage common settings for your website.',
 						'wp-plugin-bluehost'
 					) }
+					id={ 'settings-header' }
 					className={ 'wppbh-app-settings-header' }
 				/>
 
@@ -35,6 +36,7 @@ const Settings = () => {
 
 				<Container.Block
 					separator={ true }
+					id={ 'social-media-accounts-section' }
 					className={ 'wppbh-app-settings-social' }
 				>
 					<SocialMediaAccounts />
@@ -42,6 +44,7 @@ const Settings = () => {
 
 				<Container.Block
 					separator={ true }
+					id={ 'wonder-blocks-section' }
 					className={ 'wppbh-app-settings-wonder-blocks' }
 				>
 					<Container.SettingsField
@@ -66,12 +69,16 @@ const Settings = () => {
 
 				<Container.Block
 					separator={ true }
+					id={ 'content-section' }
 					className={ 'wppbh-app-settings-content' }
 				>
 					<ContentSettings />
 				</Container.Block>
 
-				<Container.Block className={ 'wppbh-app-settings-comments' }>
+				<Container.Block
+					id={ 'comments-section' }
+					className={ 'wppbh-app-settings-comments' }
+				>
 					<CommentSettings />
 				</Container.Block>
 			</Container>


### PR DESCRIPTION
## Proposed changes

Adds IDs to settings sections to be able to link to them using the `nfd-target` param.

Before only one of these links works:
- ✅ https://example.com/wp-admin/admin.php?page=bluehost&nfd-target=coming-soon-section#/settings
- ❌ https://example.com/wp-admin/admin.php?page=bluehost&nfd-target=content-section#/settings

After they both work:
- ✅ https://example.com/wp-admin/admin.php?page=bluehost&nfd-target=coming-soon-section#/settings
- ✅ https://example.com/wp-admin/admin.php?page=bluehost&nfd-target=content-section#/settings
## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
