### PR TITLE
Update description to mention PR due date is a week before

### DIFF
--- a/.github/workflows/create-milestones.yml
+++ b/.github/workflows/create-milestones.yml
@@ -41,10 +41,11 @@ jobs:
           
           # Set the date format for the milestone title and due date
           DATE=$(date -u -d "$DUE_DATE" '+%B %-d, %Y')  # Human-readable date
+          PR_DEADLINE=$(date -u -d "$DUE_DATE - 1 week" '+%B %-d, %Y')  # Date 1 week before
           DATE_ISO8601=$(date -u -d "$DUE_DATE" '+%Y-%m-%dT23:59:59Z')  # ISO8601 format
 
           # Prepare the description for the milestone
-          DESCRIPTION="The release is scheduled for $DATE, and PRs should be submitted and made mergeable by EOD $DATE. This means they should have tests passing and merge conflicts resolved. The description for the PR must include details of what is included in the PR and how to test it, and preferably new tests supporting the update.\n\nAny PRs submitted after the deadline will not be included in the release but go in the next release. This includes PRs with tests failing, no description, no screenshots/video demonstrating the update, sufficient Cypress tests, no link to associated JIRA ticket, etc. If no mergeable PRs are submitted for a release, there will be no release that week (unless there is a need for an out-of-cycle release)."
+          DESCRIPTION="The release is scheduled for $DATE. PRs must be submitted and made mergeable by EOD $PR_DEADLINE (one week before release). This means they should have tests passing and merge conflicts resolved. The description for the PR must include details of what is included in the PR and how to test it, and preferably new tests supporting the update.\n\nAny PRs submitted after the deadline will not be included in the release but go in the next release. This includes PRs with tests failing, no description, no screenshots/video demonstrating the update, sufficient Cypress tests, no link to associated JIRA ticket, etc. If no mergeable PRs are submitted for a release, there will be no release that week (unless there is a need for an out-of-cycle release)."
 
           # Debugging outputs
           echo "Debug: Human-readable Date: $DATE"


### PR DESCRIPTION
## Proposed changes

Currently, our automated workflow that creates a milestone each week has an inaccurate description. This patch fixes the description to use the correct date that PRs should be submitted by, which is one week before the release date.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
